### PR TITLE
Fix NullPointerException

### DIFF
--- a/1.11/src/main/java/me/ferdz/placeableitems/event/RightClickHandler.java
+++ b/1.11/src/main/java/me/ferdz/placeableitems/event/RightClickHandler.java
@@ -21,7 +21,7 @@ public class RightClickHandler {
 
 	@SubscribeEvent(priority = EventPriority.HIGH)
 	public void onItemRightClick(RightClickBlock e) {
-		if(e.getWorld().isRemote || e.getWorld().getBlockState(e.getPos()).getBlock() == ModBlocks.blockPlate)
+ 		if(e.getWorld().isRemote || e.getWorld().getBlockState(e.getPos()).getBlock() == ModBlocks.blockPlate || e.getFace() == null)
 			return;
 			
 		BlockPos blockPos = e.getPos().offset(e.getFace());


### PR DESCRIPTION
For some reason, in my modpack (probably SpongeForge), RightClickBlock.getFace() can be null. BlockPos.offset then ends up calling a method on null, and throws a NullPointerException.  I noticed issue #11, and he said that it only happened when you weren't in range of the "black square outline". This probably means that the event is being called for air.