### PR TITLE
Change block.isSideSolid to state.isSideSolid

### DIFF
--- a/1.12.2/src/main/java/me/ferdz/placeableitems/utils/Utils.java
+++ b/1.12.2/src/main/java/me/ferdz/placeableitems/utils/Utils.java
@@ -59,7 +59,7 @@ public class Utils {
 			if (block == Blocks.LAVA || block == Blocks.WATER || block == Blocks.TORCH || block == Blocks.AIR)
 				return false;
 			
-			if (block.isSideSolid(state, world, pos, face) || block.isNormalCube(state, world, pos) 
+			if (state.isSideSolid(world, pos, face) || block.isNormalCube(state, world, pos) 
 					|| block == Blocks.LEAVES || block == Blocks.LEAVES2)
 				return true;
 		} catch (Exception e) { /* this was a commonly thrown exception back in 1.7.10, so just to be safe let's catch it */


### PR DESCRIPTION
I don't know if it creates a bug but I changed it to remove deprecated methods. I traced it in block class. IBlockState.getBlockFaceShape is the best way but I don't know how to use.