### PR TITLE
Add a FluidHolder component. Blocks can now hold & render fluids

### DIFF
--- a/Fabric/src/main/java/me/ferdz/placeableitems/block/PlaceableItemsBlock.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/block/PlaceableItemsBlock.java
@@ -283,6 +283,10 @@ public class PlaceableItemsBlock extends BlockWithEntity {
         return this;
     }
 
+    public List<IBlockComponent> getComponents() {
+        return components;
+    }
+
     @SuppressWarnings("deprecation") // This is fine to override
     @Override
     public boolean activate(BlockState state, World worldIn, BlockPos pos, PlayerEntity player, Hand handIn, BlockHitResult hit) {

--- a/Fabric/src/main/java/me/ferdz/placeableitems/block/component/impl/BiPositionBlockComponent.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/block/component/impl/BiPositionBlockComponent.java
@@ -17,7 +17,7 @@ import net.minecraft.world.BlockView;
 
 public class BiPositionBlockComponent extends AbstractBlockComponent {
 
-    private static final BooleanProperty UP = Properties.UP;
+    public static final BooleanProperty UP = Properties.UP;
     
     @Override
     public void fillStateContainer(StateFactory.Builder<Block, BlockState> builder) {

--- a/Fabric/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
@@ -158,7 +158,7 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
                 if (!player.abilities.creativeMode) {
                     item.decrement(1);
                     if (!player.inventory.insertStack(filledBucket)) {
-                        player.dropItem(filledBucket, false);
+                        player.dropItem(filledBucket, false); // Drop the bucket in the world if the inventory is already full
                     }
                 }
 

--- a/Fabric/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
@@ -187,7 +187,7 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
                 return !player.isSneaking();
             }
 
-            SoundEvent sound = fluid.matches(FluidTags.LAVA) ? SoundEvents.ITEM_BUCKET_EMPTY_LAVA : SoundEvents.ITEM_BUCKET_EMPTY;
+            SoundEvent sound = bucketFluid.matches(FluidTags.LAVA) ? SoundEvents.ITEM_BUCKET_EMPTY_LAVA : SoundEvents.ITEM_BUCKET_EMPTY;
 
             player.playSound(sound, 1.0F, 1.0F);
             player.incrementStat(Stats.USED.getOrCreateStat(bucket));

--- a/Fabric/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
@@ -142,11 +142,11 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
         FluidHolderBlockEntity fluidTile = (FluidHolderBlockEntity) tile;
 
         if (bucket == Items.BUCKET) { // Empty bucket
-            if (fluidTile.getFluidAmount() < BUCKET_FLUID_AMOUNT) {
+            FluidStack fluidStack = fluidTile.getFluid();
+            if (fluidStack.getAmount() < BUCKET_FLUID_AMOUNT) {
                 return false;
             }
 
-            FluidStack fluidStack = fluidTile.getFluid();
             Fluid fluid = fluidStack.getFluid();
 
             SoundEvent sound = fluid.matches(FluidTags.LAVA) ? SoundEvents.ITEM_BUCKET_FILL_LAVA : SoundEvents.ITEM_BUCKET_FILL;
@@ -163,7 +163,9 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
                 }
 
                 Criterions.FILLED_BUCKET.handle((ServerPlayerEntity) player, filledBucket);
-                fluidTile.setFluidAmount(fluidTile.getFluidAmount() - BUCKET_FLUID_AMOUNT);
+                fluidStack.shrink(BUCKET_FLUID_AMOUNT);
+                fluidTile.setFluid(fluidStack);
+
                 fluidTile.sync();
             }
 
@@ -181,7 +183,7 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
 
             FluidStack fluidStack = fluidTile.getFluid();
             Fluid fluid = fluidStack.getFluid();
-            if (fluidTile.getFluidAmount() + BUCKET_FLUID_AMOUNT > maxFluidAmount || (!fluidStack.isEmpty() && bucketFluid != fluid)) {
+            if (fluidStack.getAmount() + BUCKET_FLUID_AMOUNT > maxFluidAmount || (!fluidStack.isEmpty() && bucketFluid != fluid)) {
                 return !player.isSneaking();
             }
 
@@ -199,7 +201,8 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
                 if (fluidStack.isEmpty()) {
                     fluidTile.setFluid(new FluidStack(bucketFluid, BUCKET_FLUID_AMOUNT));
                 } else {
-                    fluidTile.setFluidAmount(fluidTile.getFluidAmount() + BUCKET_FLUID_AMOUNT);
+                    fluidStack.grow(BUCKET_FLUID_AMOUNT);
+                    fluidTile.setFluid(fluidStack);
                 }
 
                 fluidTile.sync();

--- a/Fabric/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
@@ -1,0 +1,239 @@
+package me.ferdz.placeableitems.block.component.impl;
+
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicates;
+
+import me.ferdz.placeableitems.block.component.AbstractBlockComponent;
+import me.ferdz.placeableitems.blockentities.FluidHolderBlockEntity;
+import me.ferdz.placeableitems.utils.FluidStack;
+
+import net.minecraft.advancement.criterion.Criterions;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.item.BucketItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.stat.Stats;
+import net.minecraft.tag.FluidTags;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+
+/**
+ * A block component capable of holding {@link FluidStack}s.
+ *
+ * @author Parker Hawke - Choco
+ */
+public class FluidHolderBlockComponent extends AbstractBlockComponent {
+
+    private static final int BUCKET_FLUID_AMOUNT = 1000;
+
+    private final int maxFluidAmount;
+    private final boolean renderFluid;
+    private final Predicate<Fluid> fluidPredicate;
+
+    /**
+     * Create a new FluidHolderBlockComponent with a maximum fluid amount, whether or not
+     * the fluid should be rendered and a fluid predicate.
+     *
+     * @param maxFluidAmount the maximum fluid amount (in millibuckets. 1,000 = 1 bucket).
+     * Must be >= 0.
+     * @param renderFluid whether a fluid should be rendered for the client
+     * @param fluidPredicate a fluid validation predicate. Can hold fluids that test true.
+     * If null, an always true predicate will be used.
+     */
+    public FluidHolderBlockComponent(int maxFluidAmount, boolean renderFluid, Predicate<Fluid> fluidPredicate) {
+        Preconditions.checkArgument(maxFluidAmount >= 0, "Max fluid amount must be >= 0");
+        this.maxFluidAmount = maxFluidAmount;
+        this.renderFluid = renderFluid;
+        this.fluidPredicate = (fluidPredicate != null) ? fluidPredicate : Predicates.alwaysTrue();
+    }
+
+    /**
+     * Create a new FluidHolderBlockComponent with a maximum fluid amount and whether or
+     * not the fluid should be rendered. All fluids can be held in this holder.
+     *
+     * @param maxFluidAmount the maximum fluid amount (in millibuckets. 1,000 = 1 bucket).
+     * Must be >= 0.
+     * @param renderFluid whether a fluid should be rendered for the client
+     */
+    public FluidHolderBlockComponent(int maxFluidAmount, boolean renderFluid) {
+        this(maxFluidAmount, renderFluid, null);
+    }
+
+    /**
+     * Create a new FluidHolderBlockComponent with a maximum fluid amount and a fluid
+     * predicate. The fluid will be rendered in the world for the client.
+     *
+     * @param maxFluidAmount the maximum fluid amount (in millibuckets. 1,000 = 1 bucket).
+     * Must be >= 0.
+     * @param fluidPredicate a fluid validation predicate. Can hold fluids that test true.
+     * If null, an always true predicate will be used.
+     */
+    public FluidHolderBlockComponent(int maxFluidAmount, Predicate<Fluid> fluidPredicate) {
+        this(maxFluidAmount, true, fluidPredicate);
+    }
+
+    /**
+     * Create a new FluidHolderBlockComponent with a maximum fluid amount. The fluid will
+     * be rendered in the world for the client. All fluids can be held in this holder.
+     *
+     * @param maxFluidAmount the maximum fluid amount (in millibuckets. 1,000 = 1 bucket).
+     * Must be >= 0.
+     */
+    public FluidHolderBlockComponent(int maxFluidAmount) {
+        this(maxFluidAmount, true, null);
+    }
+
+    /**
+     * Get the maximum amount of fluid this component can hold.
+     *
+     * @return the maximum amount of fluid in millibuckets (1,000 = 1 bucket)
+     */
+    public int getMaxFluidAmount() {
+        return maxFluidAmount;
+    }
+
+    /**
+     * Check whether or not this component should render the fluid in the world.
+     *
+     * @return true if rendered in the world, false otherwise
+     */
+    public boolean shouldRenderFluid() {
+        return renderFluid;
+    }
+
+    /**
+     * Get the fluid predicate. If this predicate tests true, the fluid can be held in
+     * this holder.
+     *
+     * @return the fluid predicate
+     */
+    public Predicate<Fluid> getFluidPredicate() {
+        return fluidPredicate;
+    }
+
+    @Override
+    public boolean onBlockActivated(BlockState state, World worldIn, BlockPos pos, PlayerEntity player, Hand handIn, BlockHitResult hit) throws NotImplementedException {
+        ItemStack item = player.getStackInHand(handIn);
+        if (!(item.getItem() instanceof BucketItem)) {
+            return false;
+        }
+
+        BlockEntity tile = worldIn.getBlockEntity(pos);
+        if (!(tile instanceof FluidHolderBlockEntity)) {
+            return false;
+        }
+
+        BucketItem bucket = (BucketItem) item.getItem();
+        FluidHolderBlockEntity fluidTile = (FluidHolderBlockEntity) tile;
+
+        if (bucket == Items.BUCKET) { // Empty bucket
+            if (fluidTile.getFluidAmount() < BUCKET_FLUID_AMOUNT) {
+                return false;
+            }
+
+            FluidStack fluidStack = fluidTile.getFluid();
+            Fluid fluid = fluidStack.getFluid();
+
+            SoundEvent sound = fluid.matches(FluidTags.LAVA) ? SoundEvents.ITEM_BUCKET_FILL_LAVA : SoundEvents.ITEM_BUCKET_FILL;
+            player.playSound(sound, 1.0F, 1.0F);
+
+            if (!worldIn.isClient()) {
+                ItemStack filledBucket = new ItemStack(fluid.getBucketItem());
+
+                if (!player.abilities.creativeMode) {
+                    item.decrement(1);
+                    if (!player.inventory.insertStack(filledBucket)) {
+                        player.dropItem(filledBucket, false);
+                    }
+                }
+
+                Criterions.FILLED_BUCKET.handle((ServerPlayerEntity) player, filledBucket);
+                fluidTile.setFluidAmount(fluidTile.getFluidAmount() - BUCKET_FLUID_AMOUNT);
+                fluidTile.sync();
+            }
+
+            return true;
+        }
+        else { // Bucket with a fluid
+            Fluid bucketFluid = getFluidFromItem(bucket);
+            if (bucketFluid == Fluids.EMPTY) { // Invalid case, can't handle
+                return false;
+            }
+
+            if (!fluidPredicate.test(bucketFluid)) {
+                return !player.isSneaking();
+            }
+
+            FluidStack fluidStack = fluidTile.getFluid();
+            Fluid fluid = fluidStack.getFluid();
+            if (fluidTile.getFluidAmount() + BUCKET_FLUID_AMOUNT > maxFluidAmount || (!fluidStack.isEmpty() && bucketFluid != fluid)) {
+                return !player.isSneaking();
+            }
+
+            SoundEvent sound = fluid.matches(FluidTags.LAVA) ? SoundEvents.ITEM_BUCKET_EMPTY_LAVA : SoundEvents.ITEM_BUCKET_EMPTY;
+
+            player.playSound(sound, 1.0F, 1.0F);
+            player.incrementStat(Stats.USED.getOrCreateStat(bucket));
+
+            if (!worldIn.isClient()) {
+                if (!player.abilities.creativeMode) {
+                    item.decrement(1);
+                    player.inventory.insertStack(new ItemStack(Items.BUCKET));
+                }
+
+                if (fluidStack.isEmpty()) {
+                    fluidTile.setFluid(new FluidStack(bucketFluid, BUCKET_FLUID_AMOUNT));
+                } else {
+                    fluidTile.setFluidAmount(fluidTile.getFluidAmount() + BUCKET_FLUID_AMOUNT);
+                }
+
+                fluidTile.sync();
+            }
+        }
+
+        // We return !player.isSneaking() to ensure fluids are not placed accidentally if a fluid is not accepted (i.e. lava. That stuff hurts)
+        return !player.isSneaking();
+    }
+
+    @Override
+    public boolean hasTileEntity() {
+        return true;
+    }
+
+    @Override
+    public BlockEntity createTileEntity(BlockView world) {
+        return new FluidHolderBlockEntity();
+    }
+
+    // Really Fabric?
+    private Fluid getFluidFromItem(Item item) {
+        if (item == null) {
+            return Fluids.EMPTY;
+        }
+
+        for (Iterator<Fluid> it = Registry.FLUID.iterator(); it.hasNext();) {
+            Fluid fluid = it.next();
+            if (fluid.getBucketItem() == item && fluid.isStill(fluid.getDefaultState())) {
+                return fluid;
+            }
+        }
+
+        return Fluids.EMPTY;
+    }
+
+}

--- a/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/FluidHolderBlockEntity.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/FluidHolderBlockEntity.java
@@ -1,0 +1,129 @@
+package me.ferdz.placeableitems.blockentities;
+
+import me.ferdz.placeableitems.init.PlaceableItemBlockEntityRegistry;
+import me.ferdz.placeableitems.utils.FluidStack;
+
+import net.fabricmc.fabric.api.block.entity.BlockEntityClientSerializable;
+import net.fabricmc.fabric.api.util.NbtType;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.nbt.CompoundTag;
+
+/**
+ * Represents a block entity capable of holding a {@link FluidStack}.
+ *
+ * @author Parker Hawke - Choco
+ */
+public class FluidHolderBlockEntity extends BlockEntity implements BlockEntityClientSerializable {
+
+    private FluidStack fluid = FluidStack.EMPTY;
+
+    public FluidHolderBlockEntity() {
+        super(PlaceableItemBlockEntityRegistry.FLUID_HOLDER_BLOCK_ENTITY);
+    }
+
+    /**
+     * Set the FluidStack held by this entity.
+     *
+     * @param fluid the fluid to set. If null, empty will be used.
+     */
+    public void setFluid(FluidStack fluid) {
+        this.fluid = (fluid != null) ? fluid : FluidStack.EMPTY;
+        this.markDirty();
+    }
+
+    /**
+     * Set the Fluid to be held by this entity. Amount will be maintained.
+     * Only the fluid's type is changed.
+     *
+     * @param fluid the fluid to set. If null, empty will be used
+     *
+     * @return true if successful, false otherwise
+     */
+    public boolean setFluid(Fluid fluid) {
+        if (fluid == null) {
+            if (this.fluid.isEmpty()) {
+                return false;
+            }
+
+            this.setFluid(FluidStack.EMPTY);
+            return true;
+        }
+
+        if (this.fluid.getFluid() != fluid) {
+            this.setFluid(new FluidStack(fluid, getFluidAmount()));
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the amount of fluid held by this tile entity. If no fluid, 0 will be returned.
+     *
+     * @return this tile's fluid amount
+     */
+    public int getFluidAmount() {
+        return fluid.getAmount();
+    }
+
+    /**
+     * Set the amount of fluid held by this tile entity. If no fluid, this method fails
+     * silently.
+     *
+     * @param amount the amount of fluid to set.
+     *
+     * @return true if changed, false if no fluid is held by this tile
+     */
+    public boolean setFluidAmount(int amount) {
+        if (fluid.isEmpty()) {
+            return false;
+        }
+
+        this.fluid.setAmount(amount);
+        this.markDirty();
+        return true;
+    }
+
+    /**
+     * Get a copy of the FluidStack held by this tile entity.
+     *
+     * @return the fluid stack
+     */
+    public FluidStack getFluid() {
+        return fluid.copy();
+    }
+
+    @Override
+    public CompoundTag toTag(CompoundTag compound) {
+        super.toTag(compound);
+
+        if (!fluid.isEmpty()) {
+            compound.put("Fluid", fluid.writeToNBT(new CompoundTag()));
+        }
+
+        return compound;
+    }
+
+    @Override
+    public void fromTag(CompoundTag compound) {
+        super.fromTag(compound);
+
+        if (compound.containsKey("Fluid", NbtType.COMPOUND)) {
+            this.fluid = FluidStack.fromNBT(compound.getCompound("Fluid"));
+        }
+    }
+
+    @Override
+    public CompoundTag toClientTag(CompoundTag tag) {
+        this.fluid.writeToNBT(tag);
+        return tag;
+    }
+
+    @Override
+    public void fromClientTag(CompoundTag tag) {
+        this.fluid = FluidStack.fromNBT(tag);
+    }
+
+}

--- a/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/FluidHolderBlockEntity.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/FluidHolderBlockEntity.java
@@ -29,7 +29,7 @@ public class FluidHolderBlockEntity extends BlockEntity implements BlockEntityCl
      * @param fluid the fluid to set. If null, empty will be used.
      */
     public void setFluid(FluidStack fluid) {
-        this.fluid = (fluid != null) ? fluid : FluidStack.EMPTY;
+        this.fluid = (fluid != null) ? fluid.copy() : FluidStack.EMPTY;
         this.markDirty();
     }
 
@@ -38,52 +38,18 @@ public class FluidHolderBlockEntity extends BlockEntity implements BlockEntityCl
      * Only the fluid's type is changed.
      *
      * @param fluid the fluid to set. If null, empty will be used
-     *
-     * @return true if successful, false otherwise
      */
-    public boolean setFluid(Fluid fluid) {
+    public void setFluid(Fluid fluid) {
         if (fluid == null) {
             if (this.fluid.isEmpty()) {
-                return false;
+                return;
             }
 
             this.setFluid(FluidStack.EMPTY);
-            return true;
         }
-
-        if (this.fluid.getFluid() != fluid) {
-            this.setFluid(new FluidStack(fluid, getFluidAmount()));
-            return true;
+        else if (this.fluid.getFluid() != fluid) {
+            this.setFluid(new FluidStack(fluid, this.fluid.getAmount()));
         }
-
-        return false;
-    }
-
-    /**
-     * Get the amount of fluid held by this tile entity. If no fluid, 0 will be returned.
-     *
-     * @return this tile's fluid amount
-     */
-    public int getFluidAmount() {
-        return fluid.getAmount();
-    }
-
-    /**
-     * Set the amount of fluid held by this tile entity. If no fluid, this method fails
-     * silently.
-     *
-     * @param amount the amount of fluid to set.
-     *
-     * @return true if changed, false if no fluid is held by this tile
-     */
-    public boolean setFluidAmount(int amount) {
-        if (fluid.isEmpty()) {
-            return false;
-        }
-
-        this.fluid.setAmount(amount);
-        this.markDirty();
-        return true;
     }
 
     /**

--- a/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/renderers/FluidHolderBlockEntityRenderer.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/renderers/FluidHolderBlockEntityRenderer.java
@@ -99,7 +99,7 @@ public class FluidHolderBlockEntityRenderer extends PlaceableItemBlockEntityRend
         FluidModel model = this.fluidModels.get(block);
         Preconditions.checkState(model != null, "Missing model binding for FluidHolderTileEntity (" + tile.getClass().getName() + ")");
 
-        Vec3d rotationPoint = model.getRotationPoint(state);
+        Vec3d rotationPoint = model.getOrigin(state);
         buffer.setOffset(x + (rotationPoint.x / 16F), y + (rotationPoint.y / 16F), z + (rotationPoint.z / 16F));
 
         // Render the fluid

--- a/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/renderers/FluidHolderBlockEntityRenderer.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/renderers/FluidHolderBlockEntityRenderer.java
@@ -119,11 +119,14 @@ public class FluidHolderBlockEntityRenderer extends PlaceableItemBlockEntityRend
         BlockPos pos = tile.getPos();
         AllVertexBoundingBox bounds = model.getRenderBounds(state);
 
+        // Conditionally cull and render specific directions
         if (model.shouldRender(state, Direction.DOWN)) {
+            // Fetch the value of the lights that strike this quad
             int downCombined = getWorld().getLightmapIndex(pos.down(), 0);
             int downLMa = downCombined >> 16 & 65535;
             int downLMb = downCombined & 65535;
 
+            // Buffer quad positions, colours, texture coordinates (animated UV mappings) and light map coordinates. ORDER MATTERS HERE!
             // Two calls to texture(), different overloads. Fabric mappings here are strange. The second call represents the light map
             bufferVertex(buffer, bounds.getBackBottomLeft()).color(red, green, blue, alpha).texture(u1, v2).texture(downLMa, downLMb).next();
             bufferVertex(buffer, bounds.getFrontBottomLeft()).color(red, green, blue, alpha).texture(u1, v1).texture(downLMa, downLMb).next();
@@ -215,6 +218,11 @@ public class FluidHolderBlockEntityRenderer extends PlaceableItemBlockEntityRend
         return buffer.vertex(pos.x, pos.y, pos.z);
     }
     
+    /*
+     * A large majority of the code below is based heavily on the class mapped as "RenderHelper" in Forge's MCP mappings.
+     * No fabric counterpart was found despite it being a vanilla class in the Forge codebase.
+     * If a class that performs this logic is found in the future, this code may be deleted and replaced by its calls instead.
+     */
     private void disableStandardItemLighting() {
         GlStateManager.disableLighting();
         GlStateManager.disableLight(0);

--- a/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/renderers/FluidHolderBlockEntityRenderer.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/renderers/FluidHolderBlockEntityRenderer.java
@@ -117,7 +117,7 @@ public class FluidHolderBlockEntityRenderer extends PlaceableItemBlockEntityRend
         float blue = (color & 0xFF) / 255F;
 
         BlockPos pos = tile.getPos();
-        AllVertexBoundingBox bounds = model.getRenderBounds(state, model.shouldRecalculate(state));
+        AllVertexBoundingBox bounds = model.getRenderBounds(state);
 
         if (model.shouldRender(state, Direction.DOWN)) {
             int downCombined = getWorld().getLightmapIndex(pos.down(), 0);

--- a/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/renderers/FluidHolderBlockEntityRenderer.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/renderers/FluidHolderBlockEntityRenderer.java
@@ -200,14 +200,6 @@ public class FluidHolderBlockEntityRenderer extends PlaceableItemBlockEntityRend
         return this;
     }
 
-    /**
-     * Clear all binded fluid models from this renderer. Ill-advised for modders to invoke this method.
-     * Unexpected issues may arise including the client crashing due to missing models.
-     */
-    public void clearFluidModels() {
-        this.fluidModels.clear();
-    }
-
     private FluidHolderBlockComponent getFluidHolderBlockComponent(PlaceableItemsBlock block) {
         for (IBlockComponent component : block.getComponents()) {
             if (component instanceof FluidHolderBlockComponent) {

--- a/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/renderers/FluidHolderBlockEntityRenderer.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/renderers/FluidHolderBlockEntityRenderer.java
@@ -151,9 +151,9 @@ public class FluidHolderBlockEntityRenderer extends PlaceableItemBlockEntityRend
             int northLMb = northCombined & 65535;
 
             bufferVertex(buffer, bounds.getFrontBottomLeft()).color(red, green, blue, alpha).texture(u1, v1).texture(northLMa, northLMb).next();
-            bufferVertex(buffer, bounds.getFrontTopLeft()).color(red, green, blue, alpha).texture(u1, v2).texture(northLMa, northLMb).next();
+            bufferVertex(buffer, bounds.getFrontTopLeft()).color(red, green, blue, alpha).texture(u2, v1).texture(northLMa, northLMb).next();
             bufferVertex(buffer, bounds.getFrontTopRight()).color(red, green, blue, alpha).texture(u2, v2).texture(northLMa, northLMb).next();
-            bufferVertex(buffer, bounds.getFrontBottomRight()).color(red, green, blue, alpha).texture(u2, v1).texture(northLMa, northLMb).next();
+            bufferVertex(buffer, bounds.getFrontBottomRight()).color(red, green, blue, alpha).texture(u1, v2).texture(northLMa, northLMb).next();
         }
 
         if (model.shouldRender(state, Direction.SOUTH)) {
@@ -161,9 +161,9 @@ public class FluidHolderBlockEntityRenderer extends PlaceableItemBlockEntityRend
             int southLMa = southCombined >> 16 & 65535;
             int southLMb = southCombined & 65535;
 
-            bufferVertex(buffer, bounds.getBackBottomRight()).color(red, green, blue, alpha).texture(u2, v1).texture(southLMa, southLMb).next();
+            bufferVertex(buffer, bounds.getBackBottomRight()).color(red, green, blue, alpha).texture(u1, v2).texture(southLMa, southLMb).next();
             bufferVertex(buffer, bounds.getBackTopRight()).color(red, green, blue, alpha).texture(u2, v2).texture(southLMa, southLMb).next();
-            bufferVertex(buffer, bounds.getBackTopLeft()).color(red, green, blue, alpha).texture(u1, v2).texture(southLMa, southLMb).next();
+            bufferVertex(buffer, bounds.getBackTopLeft()).color(red, green, blue, alpha).texture(u2, v1).texture(southLMa, southLMb).next();
             bufferVertex(buffer, bounds.getBackBottomLeft()).color(red, green, blue, alpha).texture(u1, v1).texture(southLMa, southLMb).next();
         }
 

--- a/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/renderers/FluidHolderBlockEntityRenderer.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/blockentities/renderers/FluidHolderBlockEntityRenderer.java
@@ -1,0 +1,270 @@
+package me.ferdz.placeableitems.blockentities.renderers;
+
+import java.lang.ref.WeakReference;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import com.google.common.base.Preconditions;
+import com.mojang.blaze3d.platform.GlStateManager;
+
+import me.ferdz.placeableitems.block.PlaceableItemsBlock;
+import me.ferdz.placeableitems.block.component.IBlockComponent;
+import me.ferdz.placeableitems.block.component.impl.FluidHolderBlockComponent;
+import me.ferdz.placeableitems.blockentities.FluidHolderBlockEntity;
+import me.ferdz.placeableitems.client.AllVertexBoundingBox;
+import me.ferdz.placeableitems.client.model.FluidModel;
+import me.ferdz.placeableitems.utils.FluidStack;
+
+import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandler;
+import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.BufferBuilder;
+import net.minecraft.client.render.Tessellator;
+import net.minecraft.client.render.Vec3d;
+import net.minecraft.client.render.VertexFormats;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.util.math.Vector3f;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+
+import org.lwjgl.opengl.GL11;
+
+/**
+ * A fast tile entity renderer implementation for {@link FluidHolderBlockEntity} instances.
+ * Fluid holders should bind {@link FluidModel} implementations to each registered renderer
+ * instance using {@link #bind(PlaceableItemsBlock, FluidModel)}. If a
+ * {@link FluidHolderBlockComponent#shouldRenderFluid()} returns true but has no registered FluidModel,
+ * an exception will be thrown and the client will crash.
+ *
+ * @author Parker Hawke - Choco
+ */
+public class FluidHolderBlockEntityRenderer extends PlaceableItemBlockEntityRenderer<FluidHolderBlockEntity> {
+
+    private static final FloatBuffer COLOR_BUFFER = createDirectFloatBuffer(4);
+    private static final Vector3f LIGHT0_POS = createNormalizedVector(0.2F, 1.0F, -0.7F);
+    private static final Vector3f LIGHT1_POS = createNormalizedVector(-0.2F, 1.0F, 0.7F);
+
+    private final Map<PlaceableItemsBlock, FluidModel> fluidModels = new IdentityHashMap<>();
+
+    // Technically these should be reloaded on resource reload, but quite honestly, I don't really care.
+    private final Map<FluidState, WeakReference<Sprite>> fluidSprites = new IdentityHashMap<>();
+
+    @Override
+    public void render(FluidHolderBlockEntity tile, double x, double y, double z, float partialTicks, int destroyStage) {
+        super.render(tile, x, y, z, partialTicks, destroyStage);
+
+        // Tesselation to batch render all fluids in one draw call
+        Tessellator tessellator = Tessellator.getInstance();
+        BufferBuilder buffer = tessellator.getBufferBuilder();
+        this.disableStandardItemLighting();
+        GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        GlStateManager.enableBlend();
+        GlStateManager.disableCull();
+        GlStateManager.shadeModel(MinecraftClient.isAmbientOcclusionEnabled() ? GL11.GL_SMOOTH : GL11.GL_FLAT);
+        
+        buffer.begin(GL11.GL_QUADS, VertexFormats.POSITION_COLOR_UV_LMAP);
+        this.bufferRender(tile, x, y, z, buffer);
+        buffer.setOffset(0, 0, 0);
+        tessellator.draw();
+
+        this.enableStandardItemLighting();
+    }
+
+    public void bufferRender(FluidHolderBlockEntity tile, double x, double y, double z, BufferBuilder buffer) {
+        FluidStack fluidStack = tile.getFluid();
+        if (fluidStack.isEmpty()) {
+            return;
+        }
+
+        BlockState state = tile.getCachedState();
+        Block block = state.getBlock();
+        if (!(block instanceof PlaceableItemsBlock)) {
+            return;
+        }
+
+        FluidHolderBlockComponent fluidComponent = getFluidHolderBlockComponent((PlaceableItemsBlock) block);
+        Preconditions.checkState(fluidComponent != null, "FluidHolderTileEntity does not have a FluidHolderBlockComponent. This is impossible.");
+        if (!fluidComponent.shouldRenderFluid()) {
+            return;
+        }
+
+        FluidModel model = this.fluidModels.get(block);
+        Preconditions.checkState(model != null, "Missing model binding for FluidHolderTileEntity (" + tile.getClass().getName() + ")");
+
+        Vec3d rotationPoint = model.getRotationPoint(state);
+        buffer.setOffset(x + (rotationPoint.x / 16F), y + (rotationPoint.y / 16F), z + (rotationPoint.z / 16F));
+
+        // Render the fluid
+        Fluid fluid = fluidStack.getFluid();
+        FluidRenderHandler fluidRenderHandler = FluidRenderHandlerRegistry.INSTANCE.get(fluid);
+
+        Sprite still = fluidSprites.computeIfAbsent(fluid.getDefaultState(), s -> new WeakReference<>(fluidRenderHandler.getFluidSprites(getWorld(), tile.getPos(), s)[0])).get();
+        float u1 = still.getMinU(), u2 = still.getMaxU();
+        float v1 = still.getMinV(), v2 = still.getMaxV();
+
+        int color = fluidRenderHandler.getFluidColor(getWorld(), tile.getPos(), fluid.getDefaultState());
+        float alpha = 1.0f; // Fabric's rendering hooks do not allow for custom alpha tints. A full alpha value will do for now. Most all fluids will be full alpha anyways
+        float red = (color >> 16 & 0xFF) / 255F;
+        float green = (color >> 8 & 0xFF) / 255F;
+        float blue = (color & 0xFF) / 255F;
+
+        BlockPos pos = tile.getPos();
+        AllVertexBoundingBox bounds = model.getRenderBounds(state, model.shouldRecalculate(state));
+
+        if (model.shouldRender(state, Direction.DOWN)) {
+            int downCombined = getWorld().getLightmapIndex(pos.down(), 0);
+            int downLMa = downCombined >> 16 & 65535;
+            int downLMb = downCombined & 65535;
+
+            // Two calls to texture(), different overloads. Fabric mappings here are strange. The second call represents the light map
+            bufferVertex(buffer, bounds.getBackBottomLeft()).color(red, green, blue, alpha).texture(u1, v2).texture(downLMa, downLMb).next();
+            bufferVertex(buffer, bounds.getFrontBottomLeft()).color(red, green, blue, alpha).texture(u1, v1).texture(downLMa, downLMb).next();
+            bufferVertex(buffer, bounds.getFrontBottomRight()).color(red, green, blue, alpha).texture(u2, v1).texture(downLMa, downLMb).next();
+            bufferVertex(buffer, bounds.getBackBottomRight()).color(red, green, blue, alpha).texture(u2, v2).texture(downLMa, downLMb).next();
+        }
+
+        if (model.shouldRender(state, Direction.UP)) {
+            int upCombined = getWorld().getLightmapIndex(pos.up(), 0);
+            int upLMa = upCombined >> 16 & 65535;
+            int upLMb = upCombined & 65535;
+
+            bufferVertex(buffer, bounds.getBackTopLeft()).color(red, green, blue, alpha).texture(u1, v2).texture(upLMa, upLMb).next();
+            bufferVertex(buffer, bounds.getFrontTopLeft()).color(red, green, blue, alpha).texture(u1, v1).texture(upLMa, upLMb).next();
+            bufferVertex(buffer, bounds.getFrontTopRight()).color(red, green, blue, alpha).texture(u2, v1).texture(upLMa, upLMb).next();
+            bufferVertex(buffer, bounds.getBackTopRight()).color(red, green, blue, alpha).texture(u2, v2).texture(upLMa, upLMb).next();
+        }
+
+        if (model.shouldRender(state, Direction.NORTH)) {
+            int northCombined = getWorld().getLightmapIndex(pos.north(), 0);
+            int northLMa = northCombined >> 16 & 65535;
+            int northLMb = northCombined & 65535;
+
+            bufferVertex(buffer, bounds.getFrontBottomLeft()).color(red, green, blue, alpha).texture(u1, v1).texture(northLMa, northLMb).next();
+            bufferVertex(buffer, bounds.getFrontTopLeft()).color(red, green, blue, alpha).texture(u1, v2).texture(northLMa, northLMb).next();
+            bufferVertex(buffer, bounds.getFrontTopRight()).color(red, green, blue, alpha).texture(u2, v2).texture(northLMa, northLMb).next();
+            bufferVertex(buffer, bounds.getFrontBottomRight()).color(red, green, blue, alpha).texture(u2, v1).texture(northLMa, northLMb).next();
+        }
+
+        if (model.shouldRender(state, Direction.SOUTH)) {
+            int southCombined = getWorld().getLightmapIndex(pos.south(), 0);
+            int southLMa = southCombined >> 16 & 65535;
+            int southLMb = southCombined & 65535;
+
+            bufferVertex(buffer, bounds.getBackBottomRight()).color(red, green, blue, alpha).texture(u2, v1).texture(southLMa, southLMb).next();
+            bufferVertex(buffer, bounds.getBackTopRight()).color(red, green, blue, alpha).texture(u2, v2).texture(southLMa, southLMb).next();
+            bufferVertex(buffer, bounds.getBackTopLeft()).color(red, green, blue, alpha).texture(u1, v2).texture(southLMa, southLMb).next();
+            bufferVertex(buffer, bounds.getBackBottomLeft()).color(red, green, blue, alpha).texture(u1, v1).texture(southLMa, southLMb).next();
+        }
+
+        if (model.shouldRender(state, Direction.WEST)) {
+            int westCombined = getWorld().getLightmapIndex(pos.west(), 0);
+            int westLMa = westCombined >> 16 & 65535;
+            int westLMb = westCombined & 65535;
+
+            bufferVertex(buffer, bounds.getBackBottomLeft()).color(red, green, blue, alpha).texture(u1, v2).texture(westLMa, westLMb).next();
+            bufferVertex(buffer, bounds.getBackTopLeft()).color(red, green, blue, alpha).texture(u2, v2).texture(westLMa, westLMb).next();
+            bufferVertex(buffer, bounds.getFrontTopLeft()).color(red, green, blue, alpha).texture(u2, v1).texture(westLMa, westLMb).next();
+            bufferVertex(buffer, bounds.getFrontBottomLeft()).color(red, green, blue, alpha).texture(u1, v1).texture(westLMa, westLMb).next();
+        }
+
+        if (model.shouldRender(state, Direction.EAST)) {
+            int eastCombined = getWorld().getLightmapIndex(pos.east(), 0);
+            int eastLMa = eastCombined >> 16 & 65535;
+            int eastLMb = eastCombined & 65535;
+
+            bufferVertex(buffer, bounds.getFrontBottomRight()).color(red, green, blue, alpha).texture(u1, v1).texture(eastLMa, eastLMb).next();
+            bufferVertex(buffer, bounds.getFrontTopRight()).color(red, green, blue, alpha).texture(u2, v1).texture(eastLMa, eastLMb).next();
+            bufferVertex(buffer, bounds.getBackTopRight()).color(red, green, blue, alpha).texture(u2, v2).texture(eastLMa, eastLMb).next();
+            bufferVertex(buffer, bounds.getBackBottomRight()).color(red, green, blue, alpha).texture(u1, v2).texture(eastLMa, eastLMb).next();
+        }
+    }
+
+    /**
+     * Bind a {@link PlaceableItemsBlock} to a {@link FluidModel} implementation.
+     *
+     * @param block the block for which to bind the model
+     * @param model the model to bind
+     *
+     * @return this instance. Allows for chained method calls
+     */
+    public FluidHolderBlockEntityRenderer bind(PlaceableItemsBlock block, FluidModel model) {
+        this.fluidModels.put(block, model);
+        return this;
+    }
+
+    /**
+     * Clear all binded fluid models from this renderer. Ill-advised for modders to invoke this method.
+     * Unexpected issues may arise including the client crashing due to missing models.
+     */
+    public void clearFluidModels() {
+        this.fluidModels.clear();
+    }
+
+    private FluidHolderBlockComponent getFluidHolderBlockComponent(PlaceableItemsBlock block) {
+        for (IBlockComponent component : block.getComponents()) {
+            if (component instanceof FluidHolderBlockComponent) {
+                return (FluidHolderBlockComponent) component;
+            }
+        }
+
+        return null;
+    }
+
+    // Convenience method to buffer a Vec3d. It would be much uglier otherwise
+    private BufferBuilder bufferVertex(BufferBuilder buffer, Vec3d pos) {
+        return buffer.vertex(pos.x, pos.y, pos.z);
+    }
+    
+    private void disableStandardItemLighting() {
+        GlStateManager.disableLighting();
+        GlStateManager.disableLight(0);
+        GlStateManager.disableLight(1);
+        GlStateManager.disableColorMaterial();
+    }
+
+    private void enableStandardItemLighting() {
+        GlStateManager.enableLighting();
+        GlStateManager.enableLight(0);
+        GlStateManager.enableLight(1);
+        GlStateManager.enableColorMaterial();
+        GlStateManager.colorMaterial(GL11.GL_FRONT_AND_BACK, GL11.GL_AMBIENT_AND_DIFFUSE);
+
+        GlStateManager.light(GL11.GL_COLOR_BUFFER_BIT, GL11.GL_POSITION, setColorBuffer(LIGHT0_POS.getX(), LIGHT0_POS.getY(), LIGHT0_POS.getZ(), 0.0F));
+        GlStateManager.light(GL11.GL_COLOR_BUFFER_BIT, GL11.GL_DIFFUSE, setColorBuffer(0.6F, 0.6F, 0.6F, 1.0F));
+        GlStateManager.light(GL11.GL_COLOR_BUFFER_BIT, GL11.GL_AMBIENT, setColorBuffer(0.0F, 0.0F, 0.0F, 1.0F));
+        GlStateManager.light(GL11.GL_COLOR_BUFFER_BIT, GL11.GL_SPECULAR, setColorBuffer(0.0F, 0.0F, 0.0F, 1.0F));
+        GlStateManager.light(GL11.GL_LIGHT1, GL11.GL_POSITION, setColorBuffer(LIGHT1_POS.getX(), LIGHT1_POS.getY(), LIGHT1_POS.getZ(), 0.0F));
+        GlStateManager.light(GL11.GL_LIGHT1, GL11.GL_DIFFUSE, setColorBuffer(0.6F, 0.6F, 0.6F, 1.0F));
+        GlStateManager.light(GL11.GL_LIGHT1, GL11.GL_AMBIENT, setColorBuffer(0.0F, 0.0F, 0.0F, 1.0F));
+        GlStateManager.light(GL11.GL_LIGHT1, GL11.GL_SPECULAR, setColorBuffer(0.0F, 0.0F, 0.0F, 1.0F));
+
+        GlStateManager.shadeModel(GL11.GL_FLAT);
+        GlStateManager.lightModel(GL11.GL_LIGHT_MODEL_AMBIENT, setColorBuffer(0.4F, 0.4F, 0.4F, 1.0F));
+    }
+
+    private FloatBuffer setColorBuffer(float red, float green, float blue, float alpha) {
+        COLOR_BUFFER.clear();
+        COLOR_BUFFER.put(red).put(green).put(blue).put(alpha);
+        COLOR_BUFFER.flip();
+        return COLOR_BUFFER;
+    }
+
+    private static synchronized FloatBuffer createDirectFloatBuffer(int capacity) {
+        return ByteBuffer.allocateDirect(capacity << 2).order(ByteOrder.nativeOrder()).asFloatBuffer();
+    }
+
+    private static Vector3f createNormalizedVector(float x, float y, float z) {
+        Vector3f vector = new Vector3f(x, y, z);
+        vector.reciprocal();
+        return vector;
+    }
+
+}

--- a/Fabric/src/main/java/me/ferdz/placeableitems/client/AllVertexBoundingBox.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/client/AllVertexBoundingBox.java
@@ -1,0 +1,267 @@
+package me.ferdz.placeableitems.client;
+
+import net.minecraft.client.render.Vec3d;
+import net.minecraft.util.math.Box;
+
+/**
+ * Represents a box defined by 8 points in the world. Unlike {@link Box}s, points
+ * are not validated. Therefore, caution must be taken when creating instances of this box
+ * as some points may not be properly named according to this class' member methods. The
+ * methods are named according to their position in the world relative to the player when facing
+ * the bounding box.
+ *
+ * @author Parker Hawke - Choco
+ */
+public class AllVertexBoundingBox {
+
+    private final Vec3d frontBottomLeft, frontBottomRight;
+    private final Vec3d frontTopLeft, frontTopRight;
+
+    private final Vec3d backBottomLeft, backBottomRight;
+    private final Vec3d backTopLeft, backTopRight;
+
+    /**
+     * Create an AllVertexBoundingBox with all 8 vertexes. It is recommended that a builder be
+     * used instead. See {@link #create()} or {@link #fromAABB(Box)}.
+     *
+     * @param frontBottomLeft the front, bottom left vertex
+     * @param frontBottomRight the front, bottom right vertex
+     * @param frontTopLeft the front, top left vertex
+     * @param frontTopRight the front, top right vertex
+     * @param backBottomLeft the back, bottom left vertex
+     * @param backBottomRight the back, bottom right vertex
+     * @param backTopLeft the back, top left vertex
+     * @param backTopRight the back, top right vertex
+     */
+    public AllVertexBoundingBox(Vec3d frontBottomLeft, Vec3d frontBottomRight, Vec3d frontTopLeft, Vec3d frontTopRight, Vec3d backBottomLeft, Vec3d backBottomRight, Vec3d backTopLeft, Vec3d backTopRight) {
+        this.frontBottomLeft = frontBottomLeft;
+        this.frontBottomRight = frontBottomRight;
+        this.frontTopLeft = frontTopLeft;
+        this.frontTopRight = frontTopRight;
+        this.backBottomLeft = backBottomLeft;
+        this.backBottomRight = backBottomRight;
+        this.backTopLeft = backTopLeft;
+        this.backTopRight = backTopRight;
+    }
+
+    /**
+     * Create an {@link AllVertexBoundingBox} based on an Box. The missing vertices will
+     * be calculated based on the min and max points from the provided bounds. The created bounding
+     * box will therefore match the bounds of the one provided.
+     *
+     * @param bounds the bounding box from which to create an AllVertexBoundingBox
+     *
+     * @return the newly created AllVertexBoundingBox
+     */
+    public static AllVertexBoundingBox fromAABB(Box bounds) {
+        return fromAABB(bounds.minX, bounds.minY, bounds.minZ, bounds.maxX, bounds.maxY, bounds.maxZ);
+    }
+
+    /**
+     * Create an {@link AllVertexBoundingBox} based on a set of coordinates. The missing vertices will
+     * be calculated based on the min and max points from the provided bounds. The created bounding
+     * box will therefore match the bounds of the one provided.
+     *
+     * @param x the first x coordinate
+     * @param y the first y coordinate
+     * @param z the first z coordinate
+     * @param deltaX the second x coordinate
+     * @param deltaY the second y coordinate
+     * @param deltaZ the second z coordinate
+     *
+     * @return the newly created AllVertexBoundingBox
+     */
+    public static AllVertexBoundingBox fromAABB(double x, double y, double z, double deltaX, double deltaY, double deltaZ) {
+        double minX = Math.min(x, deltaX);
+        double minY = Math.min(y, deltaY);
+        double minZ = Math.min(z, deltaZ);
+        double maxX = Math.max(x, deltaX);
+        double maxY = Math.max(y, deltaY);
+        double maxZ = Math.max(z, deltaZ);
+
+        return create().frontBottomLeft(minX, minY, minZ)
+                .frontBottomRight(maxX, minY, minZ)
+                .frontTopLeft(minX, maxY, minZ)
+                .frontTopRight(maxX, maxY, minZ)
+                .backBottomLeft(minX, minY, maxZ)
+                .backBottomRight(maxX, minY, maxZ)
+                .backTopLeft(minX, maxY, maxZ)
+                .backTopRight(maxX, maxY, maxZ).build();
+    }
+
+    /**
+     * Get a builder instance to create an {@link AllVertexBoundingBox}.
+     *
+     * @return the builder instance
+     */
+    public static AllVertexBoundingBox.Builder create() {
+        return new AllVertexBoundingBox.Builder();
+    }
+
+    /**
+     * Get the front, bottom left vertex of this bounding box.
+     *
+     * @return the front, bottom left vertex
+     */
+    public Vec3d getFrontBottomLeft() {
+        return frontBottomLeft;
+    }
+
+    /**
+     * Get the front, bottom right vertex of this bounding box.
+     *
+     * @return the front, bottom right vertex
+     */
+    public Vec3d getFrontBottomRight() {
+        return frontBottomRight;
+    }
+
+    /**
+     * Get the front, top left vertex of this bounding box.
+     *
+     * @return the front, top left vertex
+     */
+    public Vec3d getFrontTopLeft() {
+        return frontTopLeft;
+    }
+
+    /**
+     * Get the front, top right vertex of this bounding box.
+     *
+     * @return the front, top right vertex
+     */
+    public Vec3d getFrontTopRight() {
+        return frontTopRight;
+    }
+
+    /**
+     * Get the back, bottom left vertex of this bounding box.
+     *
+     * @return the back, bottom left vertex
+     */
+    public Vec3d getBackBottomLeft() {
+        return backBottomLeft;
+    }
+
+    /**
+     * Get the back, bottom right vertex of this bounding box.
+     *
+     * @return the back, bottom right vertex
+     */
+    public Vec3d getBackBottomRight() {
+        return backBottomRight;
+    }
+
+    /**
+     * Get the back, top left vertex of this bounding box.
+     *
+     * @return the back, top left vertex
+     */
+    public Vec3d getBackTopLeft() {
+        return backTopLeft;
+    }
+
+    /**
+     * Get the back, top right vertex of this bounding box.
+     *
+     * @return the back, top right vertex
+     */
+    public Vec3d getBackTopRight() {
+        return backTopRight;
+    }
+
+    /**
+     * Rotate this bounding box clockwise around the y axis.
+     *
+     * @param radians the amount (in radians) by which to rotate this bounding box.
+     *
+     * @return a new {@link AllVertexBoundingBox} rotated clockwise by the specified radians
+     */
+    public AllVertexBoundingBox rotateAroundY(double radians) {
+        double sin = Math.sin(radians), cos = Math.cos(radians);
+
+        double frontBottomLeftRotatedX = (frontBottomLeft.x * cos) + (frontBottomLeft.z * sin);
+        double frontBottomLeftRotatedZ = (-frontBottomLeft.x * sin) + (frontBottomLeft.z * cos);
+        double frontBottomRightRotatedX = (frontBottomRight.x * cos) + (frontBottomRight.z * sin);
+        double frontBottomRightRotatedZ = (-frontBottomRight.x * sin) + (frontBottomRight.z * cos);
+        double frontTopLeftRotatedX = (frontTopLeft.x * cos) + (frontTopLeft.z * sin);
+        double frontTopLeftRotatedZ = (-frontTopLeft.x * sin) + (frontTopLeft.z * cos);
+        double frontTopRightRotatedX = (frontTopRight.x * cos) + (frontTopRight.z * sin);
+        double frontTopRightRotatedZ = (-frontTopRight.x * sin) + (frontTopRight.z * cos);
+
+        double backBottomLeftRotatedX = (backBottomLeft.x * cos) + (backBottomLeft.z * sin);
+        double backBottomLeftRotatedZ = (-backBottomLeft.x * sin) + (backBottomLeft.z * cos);
+        double backBottomRightRotatedX = (backBottomRight.x * cos) + (backBottomRight.z * sin);
+        double backBottomRightRotatedZ = (-backBottomRight.x * sin) + (backBottomRight.z * cos);
+        double backTopLeftRotatedX = (backTopLeft.x * cos) + (backTopLeft.z * sin);
+        double backTopLeftRotatedZ = (-backTopLeft.x * sin) + (backTopLeft.z * cos);
+        double backTopRightRotatedX = (backTopRight.x * cos) + (backTopRight.z * sin);
+        double backTopRightRotatedZ = (-backTopRight.x * sin) + (backTopRight.z * cos);
+
+        return create().frontBottomLeft(frontBottomLeftRotatedX, frontBottomLeft.y, frontBottomLeftRotatedZ)
+                .frontBottomRight(frontBottomRightRotatedX, frontBottomRight.y, frontBottomRightRotatedZ)
+                .frontTopLeft(frontTopLeftRotatedX, frontTopLeft.y, frontTopLeftRotatedZ)
+                .frontTopRight(frontTopRightRotatedX, frontTopRight.y, frontTopRightRotatedZ)
+                .backBottomLeft(backBottomLeftRotatedX, backBottomLeft.y, backBottomLeftRotatedZ)
+                .backBottomRight(backBottomRightRotatedX, backBottomRight.y, backBottomRightRotatedZ)
+                .backTopLeft(backTopLeftRotatedX, backTopLeft.y, backTopLeftRotatedZ)
+                .backTopRight(backTopRightRotatedX, backTopRight.y, backTopRightRotatedZ).build();
+    }
+
+    public static class Builder {
+
+        private Vec3d frontBottomLeft, frontBottomRight;
+        private Vec3d frontTopLeft, frontTopRight;
+
+        private Vec3d backBottomLeft, backBottomRight;
+        private Vec3d backTopLeft, backTopRight;
+
+        private Builder() { }
+
+        public Builder frontBottomLeft(double x, double y, double z) {
+            this.frontBottomLeft = new Vec3d(x, y, z);
+            return this;
+        }
+
+        public Builder frontBottomRight(double x, double y, double z) {
+            this.frontBottomRight = new Vec3d(x, y, z);
+            return this;
+        }
+
+        public Builder frontTopLeft(double x, double y, double z) {
+            this.frontTopLeft = new Vec3d(x, y, z);
+            return this;
+        }
+
+        public Builder frontTopRight(double x, double y, double z) {
+            this.frontTopRight = new Vec3d(x, y, z);
+            return this;
+        }
+
+        public Builder backBottomLeft(double x, double y, double z) {
+            this.backBottomLeft = new Vec3d(x, y, z);
+            return this;
+        }
+
+        public Builder backBottomRight(double x, double y, double z) {
+            this.backBottomRight = new Vec3d(x, y, z);
+            return this;
+        }
+
+        public Builder backTopLeft(double x, double y, double z) {
+            this.backTopLeft = new Vec3d(x, y, z);
+            return this;
+        }
+
+        public Builder backTopRight(double x, double y, double z) {
+            this.backTopRight = new Vec3d(x, y, z);
+            return this;
+        }
+
+        public AllVertexBoundingBox build() {
+            return new AllVertexBoundingBox(frontBottomLeft, frontBottomRight, frontTopLeft, frontTopRight, backBottomLeft, backBottomRight, backTopLeft, backTopRight);
+        }
+
+    }
+
+}

--- a/Fabric/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
@@ -32,7 +32,7 @@ import net.minecraft.util.math.Direction;
  */
 public abstract class FluidModel {
 
-    private static final Vec3d ZEROED_OFFSET = new Vec3d(0.0D, 0.0D, 0.0D);
+    private static final Vec3d ZEROED_ORIGIN = new Vec3d(0.0D, 0.0D, 0.0D);
 
     private final Map<BlockState, AllVertexBoundingBox> renderCache = new IdentityHashMap<>();
 
@@ -59,7 +59,7 @@ public abstract class FluidModel {
      * no model has yet been cached for the provided state, or {@link #shouldRecalculate(BlockState)}
      * returns true.
      * <p>
-     * These bounds support negative values and will be relative to {@link #getRotationPoint(BlockState)}.
+     * These bounds support negative values and will be relative to {@link #getOrigin(BlockState)}.
      *
      * @param state the state whose render bounds to calculate
      *
@@ -99,16 +99,18 @@ public abstract class FluidModel {
     }
 
     /**
-     * Get a pixel-scaled vector (values ranging from 0 - 16) for which this model may be rotated.
+     * Get a pixel-scaled vector (values ranging from 0 - 16) for which this model may be rotated and positioned.
      * {@link #calculateRenderBounds(BlockState)} will be rendered relative to this point. This value defaults
-     * to (0, 0, 0), the pixel relative to the origin of the block
+     * to (0, 0, 0), the pixel positioned at the origin of the block relative to the floored block coordinates.
+     * <p>
+     * The point of origin will offset the rendering position and determine the point of rotation for this model.
      *
-     * @param state the state whose rotation point to get
+     * @param state the state whose origin point to get
      *
      * @return the rotation point
      */
-    public Vec3d getRotationPoint(BlockState state) {
-        return ZEROED_OFFSET;
+    public Vec3d getOrigin(BlockState state) {
+        return ZEROED_ORIGIN;
     }
 
     /**

--- a/Fabric/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
@@ -32,8 +32,6 @@ import net.minecraft.util.math.Direction;
  */
 public abstract class FluidModel {
 
-    private static final Vec3d ZEROED_ORIGIN = new Vec3d(0.0D, 0.0D, 0.0D);
-
     private final Map<BlockState, AllVertexBoundingBox> renderCache = new IdentityHashMap<>();
 
     /**
@@ -100,8 +98,8 @@ public abstract class FluidModel {
 
     /**
      * Get a pixel-scaled vector (values ranging from 0 - 16) for which this model may be rotated and positioned.
-     * {@link #calculateRenderBounds(BlockState)} will be rendered relative to this point. This value defaults
-     * to (0, 0, 0), the pixel positioned at the origin of the block relative to the floored block coordinates.
+     * {@link #calculateRenderBounds(BlockState)} will be rendered relative to this point. (0, 0, 0) is defined
+     * as the pixel positioned at the origin of the block relative to the floored block coordinates.
      * <p>
      * The point of origin will offset the rendering position and determine the point of rotation for this model.
      *
@@ -109,9 +107,7 @@ public abstract class FluidModel {
      *
      * @return the rotation point
      */
-    public Vec3d getOrigin(BlockState state) {
-        return ZEROED_ORIGIN;
-    }
+    public abstract Vec3d getOrigin(BlockState state);
 
     /**
      * Check whether or not the render bounds for the specified state should be recalculated. The

--- a/Fabric/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
@@ -37,21 +37,21 @@ public abstract class FluidModel {
     private final Map<BlockState, AllVertexBoundingBox> renderCache = new IdentityHashMap<>();
 
     /**
-     * Get the rendering bounds for this model from the render cache (if present) and optionally
-     * recalculate the cached model. If a model is not present, it will be calculated and cached.
+     * Get the rendering bounds for this model from the render cache (if present). If a model is not
+     * present, it will be calculated and cached. Additionally, the model will be recalculated if the
+     * result of {@link #shouldRecalculate(BlockState)} is true.
      *
      * @param state the state whose model to retrieve
-     * @param recalculate whether or not to recalculate the model
      *
      * @return the rendering bounds
      */
-    public final AllVertexBoundingBox getRenderBounds(BlockState state, boolean recalculate) {
-        return recalculate ? renderCache.compute(state, (s, existing) -> calculateRenderBounds(s)) : renderCache.computeIfAbsent(state, this::calculateRenderBounds);
+    public final AllVertexBoundingBox getRenderBounds(BlockState state) {
+        return shouldRecalculate(state) ? renderCache.compute(state, (s, existing) -> calculateRenderBounds(s)) : renderCache.computeIfAbsent(state, this::calculateRenderBounds);
     }
 
     /**
      * Calculate the rendering bounds for this model. This method does not account for cached models
-     * and should be used sparingly. Method callers should use {@link #getRenderBounds(BlockState, boolean)}
+     * and should be used sparingly. Method callers should use {@link #getRenderBounds(BlockState)}
      * instead to ensure a cached value is retrieved instead.
      * <p>
      * Implementations should consider the state's rotation and other states the block may have. Each

--- a/Fabric/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
@@ -1,0 +1,131 @@
+package me.ferdz.placeableitems.client.model;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import me.ferdz.placeableitems.block.component.impl.FluidHolderBlockComponent;
+import me.ferdz.placeableitems.blockentities.renderers.FluidHolderBlockEntityRenderer;
+import me.ferdz.placeableitems.client.AllVertexBoundingBox;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.client.render.Vec3d;
+import net.minecraft.util.math.Direction;
+
+/**
+ * Represents a model definition for a fluid renderable in a {@link FluidHolderBlockComponent}.
+ * Models should cache model data where possible (including rotation points and render bounds)
+ * and return them where necessary.
+ * <p>
+ * All states will have their render bounds cached and may be
+ * recalculated at any time such that {@link #shouldRecalculate(BlockState)} returns true. Please
+ * be cautious when returning true in the aforementioned method such that any computationally-expensive
+ * calculations will be re-run (however {@link #calculateRenderBounds(BlockState)} is implemented).
+ * <p>
+ * FluidModel implementations should be registered during client setup with the
+ * {@link FluidHolderBlockEntityRenderer#bind(me.ferdz.placeableitems.block.PlaceableItemsBlock, FluidModel)}
+ * method. If a {@link FluidHolderBlockComponent#shouldRenderFluid()} returns true but has no registered
+ * FluidModel, an exception will be thrown an the client will crash.
+ *
+ * @see FluidHolderBlockEntityRenderer#bind(me.ferdz.placeableitems.block.PlaceableItemsBlock, FluidModel)
+ *
+ * @author Parker Hawke - Choco
+ */
+public abstract class FluidModel {
+
+    private static final Vec3d ZEROED_OFFSET = new Vec3d(0.0D, 0.0D, 0.0D);
+
+    private final Map<BlockState, AllVertexBoundingBox> renderCache = new IdentityHashMap<>();
+
+    /**
+     * Get the rendering bounds for this model from the render cache (if present) and optionally
+     * recalculate the cached model. If a model is not present, it will be calculated and cached.
+     *
+     * @param state the state whose model to retrieve
+     * @param recalculate whether or not to recalculate the model
+     *
+     * @return the rendering bounds
+     */
+    public final AllVertexBoundingBox getRenderBounds(BlockState state, boolean recalculate) {
+        return recalculate ? renderCache.compute(state, (s, existing) -> calculateRenderBounds(s)) : renderCache.computeIfAbsent(state, this::calculateRenderBounds);
+    }
+
+    /**
+     * Calculate the rendering bounds for this model. This method does not account for cached models
+     * and should be used sparingly. Method callers should use {@link #getRenderBounds(BlockState, boolean)}
+     * instead to ensure a cached value is retrieved instead.
+     * <p>
+     * Implementations should consider the state's rotation and other states the block may have. Each
+     * unique state will be cached in the model's render cache. This method will only be called such that
+     * no model has yet been cached for the provided state, or {@link #shouldRecalculate(BlockState)}
+     * returns true.
+     * <p>
+     * These bounds support negative values and will be relative to {@link #getRotationPoint(BlockState)}.
+     *
+     * @param state the state whose render bounds to calculate
+     *
+     * @return the rendering bounds
+     */
+    public abstract AllVertexBoundingBox calculateRenderBounds(BlockState state);
+
+    /**
+     * Check whether or not the provided state has been cached.
+     *
+     * @param state the state to check
+     *
+     * @return true if cached, false otherwise
+     */
+    public boolean isCached(BlockState state) {
+        return renderCache.containsKey(state);
+    }
+
+    /**
+     * Clear the render cache for this model. Models for each unique state will be lazily recalculated when
+     * required.
+     */
+    public void clearRenderCache() {
+        this.renderCache.clear();
+    }
+
+    /**
+     * Check whether or not a quad should be rendered according to the specified direction
+     *
+     * @param state the state to check
+     * @param direction the direction to check
+     *
+     * @return true if the direction should be rendered, false otherwise
+     */
+    public boolean shouldRender(BlockState state, Direction direction) {
+        return true;
+    }
+
+    /**
+     * Get a pixel-scaled vector (values ranging from 0 - 16) for which this model may be rotated.
+     * {@link #calculateRenderBounds(BlockState)} will be rendered relative to this point. This value defaults
+     * to (0, 0, 0), the pixel relative to the origin of the block
+     *
+     * @param state the state whose rotation point to get
+     *
+     * @return the rotation point
+     */
+    public Vec3d getRotationPoint(BlockState state) {
+        return ZEROED_OFFSET;
+    }
+
+    /**
+     * Check whether or not the render bounds for the specified state should be recalculated. The
+     * result of this method is considered by the {@link FluidHolderBlockEntityRenderer} when fetching a cached
+     * model.
+     * <p>
+     * Caution should be had when overiding this method. Such that this method returns true, rendering
+     * bounds will be calculated for this state and {@link #calculateRenderBounds(BlockState)} will be
+     * invoked.
+     *
+     * @param state the state to check
+     *
+     * @return true if the model should be recalculated
+     */
+    public boolean shouldRecalculate(BlockState state) {
+        return false;
+    }
+
+}

--- a/Fabric/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
@@ -1,0 +1,39 @@
+package me.ferdz.placeableitems.client.model;
+
+import me.ferdz.placeableitems.block.PlaceableItemsBlock;
+import me.ferdz.placeableitems.block.component.impl.BiPositionBlockComponent;
+import me.ferdz.placeableitems.client.AllVertexBoundingBox;
+import me.ferdz.placeableitems.init.PlaceableItemsBlockRegistry;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.client.render.Vec3d;
+import net.minecraft.util.math.Direction;
+
+/**
+ * An implementation of {@link FluidModel} for the {@link PlaceableItemsBlockRegistry#GLASS_BOTTLE}.
+ *
+ * @author Parker Hawke - Choco
+ */
+public class GlassBottleFluidModel extends FluidModel {
+
+    private static final Vec3d ROTATION_POINT = new Vec3d(8.0D, 1.0D, 8.0D);
+    private static final Vec3d UP_ROTATION_POINT = new Vec3d(8.0D, 5.0D, 8.0D);
+
+    private static final AllVertexBoundingBox BOUNDS = AllVertexBoundingBox.fromAABB(-2.5 / 16.0, 0.0D, -2.5 / 16.0, 2.5 / 16.0, 4 / 16.0, 2.5 / 16.0);
+
+    @Override
+    public AllVertexBoundingBox calculateRenderBounds(BlockState state) {
+        return BOUNDS.rotateAroundY(Math.toRadians((-state.get(PlaceableItemsBlock.ROTATION) * 360F / 16.0F)));
+    }
+
+    @Override
+    public Vec3d getRotationPoint(BlockState state) {
+        return state.get(BiPositionBlockComponent.UP) ? UP_ROTATION_POINT : ROTATION_POINT;
+    }
+
+    @Override
+    public boolean shouldRender(BlockState state, Direction direction) {
+        return direction != Direction.DOWN;
+    }
+
+}

--- a/Fabric/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
@@ -16,8 +16,8 @@ import net.minecraft.util.math.Direction;
  */
 public class GlassBottleFluidModel extends FluidModel {
 
-    private static final Vec3d ROTATION_POINT = new Vec3d(8.0D, 1.0D, 8.0D);
-    private static final Vec3d UP_ROTATION_POINT = new Vec3d(8.0D, 5.0D, 8.0D);
+    private static final Vec3d ORIGIN = new Vec3d(8.0D, 1.0D, 8.0D);
+    private static final Vec3d UP_ORIGIN = new Vec3d(8.0D, 5.0D, 8.0D);
 
     private static final AllVertexBoundingBox BOUNDS = AllVertexBoundingBox.fromAABB(-2.5 / 16.0, 0.0D, -2.5 / 16.0, 2.5 / 16.0, 4 / 16.0, 2.5 / 16.0);
 
@@ -27,8 +27,8 @@ public class GlassBottleFluidModel extends FluidModel {
     }
 
     @Override
-    public Vec3d getRotationPoint(BlockState state) {
-        return state.get(BiPositionBlockComponent.UP) ? UP_ROTATION_POINT : ROTATION_POINT;
+    public Vec3d getOrigin(BlockState state) {
+        return state.get(BiPositionBlockComponent.UP) ? UP_ORIGIN : ORIGIN;
     }
 
     @Override

--- a/Fabric/src/main/java/me/ferdz/placeableitems/init/PlaceableItemBlockEntityRegistry.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/init/PlaceableItemBlockEntityRegistry.java
@@ -1,12 +1,17 @@
 package me.ferdz.placeableitems.init;
 
 import me.ferdz.placeableitems.PlaceableItems;
+import me.ferdz.placeableitems.blockentities.FluidHolderBlockEntity;
 import me.ferdz.placeableitems.blockentities.PlaceableItemBlockEntity;
 import me.ferdz.placeableitems.blockentities.StackHolderBlockEntity;
+import me.ferdz.placeableitems.blockentities.renderers.FluidHolderBlockEntityRenderer;
 import me.ferdz.placeableitems.blockentities.renderers.PlaceableItemBlockEntityRenderer;
+import me.ferdz.placeableitems.client.model.GlassBottleFluidModel;
+
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.render.BlockEntityRendererRegistry;
+
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
@@ -14,6 +19,7 @@ import net.minecraft.util.registry.Registry;
 public final class PlaceableItemBlockEntityRegistry {
 
     public static BlockEntityType<StackHolderBlockEntity> WRITABLE_BOOK_TILE_ENTITY;
+    public static BlockEntityType<FluidHolderBlockEntity> FLUID_HOLDER_BLOCK_ENTITY;
     public static BlockEntityType<PlaceableItemBlockEntity> PLACEABLE_ITEM_BLOCK_ENTITY;
 
     public static void registerTE() {
@@ -22,6 +28,12 @@ public final class PlaceableItemBlockEntityRegistry {
                 new Identifier(PlaceableItems.MODID, "writable_book_block"),
                 BlockEntityType.Builder
                         .create(StackHolderBlockEntity::new, PlaceableItemsBlockRegistry.stackHoldingBlocks.get())
+                        .build(null));
+        FLUID_HOLDER_BLOCK_ENTITY = Registry.register(
+                Registry.BLOCK_ENTITY,
+                new Identifier(PlaceableItems.MODID, "fluid_holder_block_entity"),
+                BlockEntityType.Builder
+                        .create(FluidHolderBlockEntity::new, PlaceableItemsBlockRegistry.fluidHoldingBlocks.get())
                         .build(null));
         PLACEABLE_ITEM_BLOCK_ENTITY = Registry.register(
                 Registry.BLOCK_ENTITY,
@@ -39,7 +51,11 @@ public final class PlaceableItemBlockEntityRegistry {
         BlockEntityRendererRegistry.INSTANCE.register(
                 StackHolderBlockEntity.class,
                 new PlaceableItemBlockEntityRenderer<StackHolderBlockEntity>());
-
+        BlockEntityRendererRegistry.INSTANCE.register(
+                FluidHolderBlockEntity.class,
+                new FluidHolderBlockEntityRenderer()
+                    .bind(PlaceableItemsBlockRegistry.GLASS_BOTTLE, new GlassBottleFluidModel())
+                );
     }
 
 }

--- a/Fabric/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsBlockRegistry.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsBlockRegistry.java
@@ -81,6 +81,7 @@ public final class PlaceableItemsBlockRegistry {
 
     public static WeakReference<PlaceableItemsBlock[]> blocks;
     public static WeakReference<PlaceableItemsBlock[]> stackHoldingBlocks;
+    public static WeakReference<PlaceableItemsBlock[]> fluidHoldingBlocks;
 
     //@SubscribeEvent
     public static void onBlocksRegistry() {
@@ -368,12 +369,6 @@ public final class PlaceableItemsBlockRegistry {
                         .setShape(VoxelShapesUtil.create(10, 12, 10))
                         .register("experience_bottle_block", Items.EXPERIENCE_BOTTLE),
 
-                GLASS_BOTTLE = new PlaceableItemsBlockBuilder()
-                        .addComponent(new BiPositionBlockComponent())
-                        .build()
-                        .setShape(VoxelShapesUtil.create(10, 12, 10))
-                        .register("glass_bottle_block", Items.GLASS_BOTTLE),
-
                 GOLD_INGOT = new PlaceableItemsBlockBuilder()
                         .addComponent(new StackableBlockComponent(6))
                         .build()
@@ -409,6 +404,15 @@ public final class PlaceableItemsBlockRegistry {
                         .build()
                         .setShape(VoxelShapesUtil.create(14, 8, 14))
                         .register("enchanted_book_block", Items.ENCHANTED_BOOK)
+        });
+
+        fluidHoldingBlocks = new WeakReference<>(new PlaceableItemsBlock[] {
+                GLASS_BOTTLE = new PlaceableItemsBlockBuilder()
+                        .addComponent(new BiPositionBlockComponent())
+                        .addComponent(new FluidHolderBlockComponent(1000))
+                        .build()
+                        .setShape(VoxelShapesUtil.create(10, 12, 10))
+                        .register("glass_bottle_block", Items.GLASS_BOTTLE)
         });
     }
 

--- a/Fabric/src/main/java/me/ferdz/placeableitems/utils/FluidStack.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/utils/FluidStack.java
@@ -1,5 +1,7 @@
 package me.ferdz.placeableitems.utils;
 
+import com.google.common.base.Preconditions;
+
 import net.fabricmc.fabric.api.util.NbtType;
 
 import net.minecraft.fluid.Fluid;
@@ -43,6 +45,16 @@ public class FluidStack {
     public void setAmount(int amount) {
         this.amount = Math.max(amount, 0);
         this.updateEmptyState();
+    }
+
+    public void grow(int amount) {
+        Preconditions.checkArgument(!isEmpty(), "Cannot grow an empty fluid");
+        this.setAmount(getAmount() + amount);
+    }
+
+    public void shrink(int amount) {
+        Preconditions.checkArgument(!isEmpty(), "Cannot shrink an empty fluid");
+        this.setAmount(getAmount() - amount);
     }
 
     public int getAmount() {

--- a/Fabric/src/main/java/me/ferdz/placeableitems/utils/FluidStack.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/utils/FluidStack.java
@@ -1,0 +1,85 @@
+package me.ferdz.placeableitems.utils;
+
+import net.fabricmc.fabric.api.util.NbtType;
+
+import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+/**
+ * The sister class to ItemStack allowing for fluids to be quantifiable
+ * <p>
+ * Credits for the conceptualization of this class go towards the Forge team. This class is
+ * heavily inspired from the Forge codebase but incredibly simplified for the sake of this
+ * mod's use.
+ *
+ * @author Parker Hawke - Choco
+ */
+public class FluidStack {
+
+    public static final FluidStack EMPTY = new FluidStack(Fluids.EMPTY, 0);
+
+    private Fluid fluid;
+    private int amount;
+    private boolean empty;
+
+    public FluidStack(Fluid fluid, int amount) {
+        this.fluid = fluid;
+        this.amount = amount;
+        this.empty = (fluid == Fluids.EMPTY || amount == 0);
+    }
+
+    public void setFluid(Fluid fluid) {
+        this.fluid = fluid;
+        this.updateEmptyState();
+    }
+
+    public Fluid getFluid() {
+        return empty ? Fluids.EMPTY : fluid;
+    }
+
+    public void setAmount(int amount) {
+        this.amount = Math.max(amount, 0);
+        this.updateEmptyState();
+    }
+
+    public int getAmount() {
+        return empty ? 0 : amount;
+    }
+
+    public boolean isEmpty() {
+        return empty;
+    }
+
+    public FluidStack copy() {
+        return new FluidStack(getFluid(), getAmount());
+    }
+
+    public CompoundTag writeToNBT(CompoundTag tag) {
+        tag.putString("Fluid", Registry.FLUID.getId(getFluid()).toString());
+        tag.putInt("Amount", getAmount());
+        return tag;
+    }
+
+    private void updateEmptyState() {
+        this.empty = (fluid == Fluids.EMPTY || amount <= 0);
+    }
+
+    public static FluidStack fromNBT(CompoundTag tag) {
+        Fluid fluid = Fluids.EMPTY;
+        int amount = 0;
+
+        if (tag.containsKey("Fluid", NbtType.STRING)) {
+            fluid = Registry.FLUID.getOrEmpty(new Identifier(tag.getString("Fluid"))).orElse(Fluids.EMPTY);
+        }
+
+        if (tag.containsKey("Amount", NbtType.INT)) {
+            amount = tag.getInt("Amount");
+        }
+
+        return new FluidStack(fluid, amount);
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/PlaceableItems.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/PlaceableItems.java
@@ -1,9 +1,14 @@
 package me.ferdz.placeableitems;
 
+import me.ferdz.placeableitems.client.ClientListener;
 import me.ferdz.placeableitems.event.ItemPlaceHandler;
+import me.ferdz.placeableitems.network.PlaceableItemsPacketHandler;
 import me.ferdz.placeableitems.wiki.WikiGenerator;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.apache.logging.log4j.LogManager;
@@ -20,11 +25,17 @@ public class PlaceableItems {
 
     public PlaceableItems() {
         // Register ourselves for server and other game events we are interested in
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onCommonSetup);
+        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> FMLJavaModLoadingContext.get().getModEventBus().register(ClientListener.get()));
         MinecraftForge.EVENT_BUS.register(new ItemPlaceHandler());
 
         if(GENERATE_WIKI) {
             FMLJavaModLoadingContext.get().getModEventBus().addListener(this::generateWiki);
         }
+    }
+
+    private void onCommonSetup(FMLCommonSetupEvent event) {
+        PlaceableItemsPacketHandler.init();
     }
 
     private void generateWiki(final FMLLoadCompleteEvent e) {

--- a/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/BiPositionBlockComponent.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/BiPositionBlockComponent.java
@@ -18,7 +18,7 @@ import net.minecraft.world.IBlockReader;
 
 @WikiBlockComponentDefinition(description = "This block can be placed both at the top and bottom of another block")
 public class BiPositionBlockComponent extends AbstractBlockComponent {
-    private static final BooleanProperty UP = BlockStateProperties.UP;
+    public static final BooleanProperty UP = BlockStateProperties.UP;
 
     @Override
     public void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {

--- a/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
@@ -1,0 +1,232 @@
+package me.ferdz.placeableitems.block.component.impl;
+
+import java.util.function.Predicate;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicates;
+
+import me.ferdz.placeableitems.block.component.AbstractBlockComponent;
+import me.ferdz.placeableitems.network.PlaceableItemsPacketHandler;
+import me.ferdz.placeableitems.network.SUpdateFluidHolderPacket;
+import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
+import me.ferdz.placeableitems.wiki.WikiBlockComponentDefinition;
+
+import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.item.BucketItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.stats.Stats;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.Hand;
+import net.minecraft.util.SoundEvent;
+import net.minecraft.util.SoundEvents;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraft.world.IBlockReader;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.IChunk;
+
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.network.PacketDistributor;
+
+/**
+ * A block component capable of holding {@link FluidStack}s.
+ *
+ * @author Parker Hawke - Choco
+ */
+@WikiBlockComponentDefinition(description = "This block can hold fluids. Right click with a bucket to fill or empty fluids.")
+public class FluidHolderBlockComponent extends AbstractBlockComponent {
+
+    private static final int BUCKET_FLUID_AMOUNT = 1000;
+
+    private final int maxFluidAmount;
+    private final boolean renderFluid;
+    private final Predicate<Fluid> fluidPredicate;
+
+    /**
+     * Create a new FluidHolderBlockComponent with a maximum fluid amount, whether or not
+     * the fluid should be rendered and a fluid predicate.
+     *
+     * @param maxFluidAmount the maximum fluid amount (in millibuckets. 1,000 = 1 bucket).
+     * Must be >= 0.
+     * @param renderFluid whether a fluid should be rendered for the client
+     * @param fluidPredicate a fluid validation predicate. Can hold fluids that test true.
+     * If null, an always true predicate will be used.
+     */
+    public FluidHolderBlockComponent(int maxFluidAmount, boolean renderFluid, Predicate<Fluid> fluidPredicate) {
+        Preconditions.checkArgument(maxFluidAmount >= 0, "Max fluid amount must be >= 0");
+        this.maxFluidAmount = maxFluidAmount;
+        this.renderFluid = renderFluid;
+        this.fluidPredicate = (fluidPredicate != null) ? fluidPredicate : Predicates.alwaysTrue();
+    }
+
+    /**
+     * Create a new FluidHolderBlockComponent with a maximum fluid amount and whether or
+     * not the fluid should be rendered. All fluids can be held in this holder.
+     *
+     * @param maxFluidAmount the maximum fluid amount (in millibuckets. 1,000 = 1 bucket).
+     * Must be >= 0.
+     * @param renderFluid whether a fluid should be rendered for the client
+     */
+    public FluidHolderBlockComponent(int maxFluidAmount, boolean renderFluid) {
+        this(maxFluidAmount, renderFluid, null);
+    }
+
+    /**
+     * Create a new FluidHolderBlockComponent with a maximum fluid amount and a fluid
+     * predicate. The fluid will be rendered in the world for the client.
+     *
+     * @param maxFluidAmount the maximum fluid amount (in millibuckets. 1,000 = 1 bucket).
+     * Must be >= 0.
+     * @param fluidPredicate a fluid validation predicate. Can hold fluids that test true.
+     * If null, an always true predicate will be used.
+     */
+    public FluidHolderBlockComponent(int maxFluidAmount, Predicate<Fluid> fluidPredicate) {
+        this(maxFluidAmount, true, fluidPredicate);
+    }
+
+    /**
+     * Create a new FluidHolderBlockComponent with a maximum fluid amount. The fluid will
+     * be rendered in the world for the client. All fluids can be held in this holder.
+     *
+     * @param maxFluidAmount the maximum fluid amount (in millibuckets. 1,000 = 1 bucket).
+     * Must be >= 0.
+     */
+    public FluidHolderBlockComponent(int maxFluidAmount) {
+        this(maxFluidAmount, true, null);
+    }
+
+    /**
+     * Get the maximum amount of fluid this component can hold.
+     *
+     * @return the maximum amount of fluid in millibuckets (1,000 = 1 bucket)
+     */
+    public int getMaxFluidAmount() {
+        return maxFluidAmount;
+    }
+
+    /**
+     * Check whether or not this component should render the fluid in the world.
+     *
+     * @return true if rendered in the world, false otherwise
+     */
+    public boolean shouldRenderFluid() {
+        return renderFluid;
+    }
+
+    /**
+     * Get the fluid predicate. If this predicate tests true, the fluid can be held in
+     * this holder.
+     *
+     * @return the fluid predicate
+     */
+    public Predicate<Fluid> getFluidPredicate() {
+        return fluidPredicate;
+    }
+
+    @Override
+    public boolean onBlockActivated(BlockState state, World worldIn, BlockPos pos, PlayerEntity player, Hand handIn, BlockRayTraceResult hit) throws NotImplementedException {
+        ItemStack item = player.getHeldItem(handIn);
+        if (!(item.getItem() instanceof BucketItem)) {
+            return false;
+        }
+
+        TileEntity tile = worldIn.getTileEntity(pos);
+        if (!(tile instanceof FluidHolderTileEntity)) {
+            return false;
+        }
+
+        BucketItem bucket = (BucketItem) item.getItem();
+        FluidHolderTileEntity fluidTile = (FluidHolderTileEntity) tile;
+
+        if (bucket == Items.BUCKET) { // Empty bucket
+            if (fluidTile.getFluidAmount() < BUCKET_FLUID_AMOUNT) {
+                return false;
+            }
+
+            FluidStack fluidStack = fluidTile.getFluid();
+            Fluid fluid = fluidStack.getFluid();
+
+            SoundEvent sound = fluid.getAttributes().getEmptySound(fluidStack);
+            if (sound == null) {
+                sound = fluid.isIn(FluidTags.LAVA) ? SoundEvents.ITEM_BUCKET_FILL_LAVA : SoundEvents.ITEM_BUCKET_FILL;
+            }
+
+            player.playSound(sound, 1.0F, 1.0F);
+
+            if (!worldIn.isRemote) {
+                ItemStack filledBucket = new ItemStack(fluid.getFilledBucket());
+
+                if (!player.abilities.isCreativeMode) {
+                    item.shrink(1);
+                    if (!player.inventory.addItemStackToInventory(filledBucket)) {
+                        player.dropItem(filledBucket, false);
+                    }
+                }
+
+                CriteriaTriggers.FILLED_BUCKET.trigger((ServerPlayerEntity) player, filledBucket);
+                fluidTile.setFluidAmount(fluidTile.getFluidAmount() - BUCKET_FLUID_AMOUNT);
+
+                IChunk chunk = worldIn.getChunk(pos);
+                if (chunk instanceof Chunk) {
+                    PlaceableItemsPacketHandler.INSTANCE.send(PacketDistributor.TRACKING_CHUNK.with(() -> (Chunk) chunk), new SUpdateFluidHolderPacket(fluidTile));
+                }
+            }
+
+            return true;
+        }
+        else if (fluidPredicate.test(bucket.getFluid())) { // Bucket with a fluid
+            FluidStack fluidStack = fluidTile.getFluid();
+            Fluid fluid = fluidStack.getFluid();
+            if (fluidTile.getFluidAmount() + BUCKET_FLUID_AMOUNT > maxFluidAmount || (!fluidStack.isEmpty() && bucket.getFluid() != fluid)) {
+                return !player.isSneaking();
+            }
+
+            SoundEvent sound = fluid.getAttributes().getEmptySound(fluidStack);
+            if (sound == null) {
+                sound = fluid.isIn(FluidTags.LAVA) ? SoundEvents.ITEM_BUCKET_EMPTY_LAVA : SoundEvents.ITEM_BUCKET_EMPTY;
+            }
+
+            player.playSound(sound, 1.0F, 1.0F);
+            player.addStat(Stats.ITEM_USED.get(bucket));
+
+            if (!worldIn.isRemote) {
+                if (!player.abilities.isCreativeMode) {
+                    item.shrink(1);
+                    player.addItemStackToInventory(new ItemStack(Items.BUCKET));
+                }
+
+                if (fluidStack.isEmpty()) {
+                    fluidTile.setFluid(new FluidStack(bucket.getFluid(), BUCKET_FLUID_AMOUNT));
+                } else {
+                    fluidTile.setFluidAmount(fluidTile.getFluidAmount() + BUCKET_FLUID_AMOUNT);
+                }
+
+                IChunk chunk = worldIn.getChunk(pos);
+                if (chunk instanceof Chunk) {
+                    PlaceableItemsPacketHandler.INSTANCE.send(PacketDistributor.TRACKING_CHUNK.with(() -> (Chunk) chunk), new SUpdateFluidHolderPacket(fluidTile));
+                }
+            }
+        }
+
+        // We return !player.isSneaking() to ensure fluids are not placed accidentally if a fluid is not accepted (i.e. lava. That stuff hurts)
+        return !player.isSneaking();
+    }
+
+    @Override
+    public boolean hasTileEntity(BlockState state) {
+        return true;
+    }
+
+    @Override
+    public TileEntity createTileEntity(BlockState state, IBlockReader world) {
+        return new FluidHolderTileEntity();
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
@@ -146,11 +146,11 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
         FluidHolderTileEntity fluidTile = (FluidHolderTileEntity) tile;
 
         if (bucket == Items.BUCKET) { // Empty bucket
-            if (fluidTile.getFluidAmount() < BUCKET_FLUID_AMOUNT) {
+            FluidStack fluidStack = fluidTile.getFluid();
+            if (fluidStack.getAmount() < BUCKET_FLUID_AMOUNT) {
                 return false;
             }
 
-            FluidStack fluidStack = fluidTile.getFluid();
             Fluid fluid = fluidStack.getFluid();
 
             SoundEvent sound = fluid.getAttributes().getEmptySound(fluidStack);
@@ -171,7 +171,8 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
                 }
 
                 CriteriaTriggers.FILLED_BUCKET.trigger((ServerPlayerEntity) player, filledBucket);
-                fluidTile.setFluidAmount(fluidTile.getFluidAmount() - BUCKET_FLUID_AMOUNT);
+                fluidStack.shrink(BUCKET_FLUID_AMOUNT);
+                fluidTile.setFluid(fluidStack);
 
                 IChunk chunk = worldIn.getChunk(pos);
                 if (chunk instanceof Chunk) {
@@ -184,7 +185,7 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
         else if (fluidPredicate.test(bucket.getFluid())) { // Bucket with a fluid
             FluidStack fluidStack = fluidTile.getFluid();
             Fluid fluid = fluidStack.getFluid();
-            if (fluidTile.getFluidAmount() + BUCKET_FLUID_AMOUNT > maxFluidAmount || (!fluidStack.isEmpty() && bucket.getFluid() != fluid)) {
+            if (fluidStack.getAmount() + BUCKET_FLUID_AMOUNT > maxFluidAmount || (!fluidStack.isEmpty() && bucket.getFluid() != fluid)) {
                 return !player.isSneaking();
             }
 
@@ -205,7 +206,8 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
                 if (fluidStack.isEmpty()) {
                     fluidTile.setFluid(new FluidStack(bucket.getFluid(), BUCKET_FLUID_AMOUNT));
                 } else {
-                    fluidTile.setFluidAmount(fluidTile.getFluidAmount() + BUCKET_FLUID_AMOUNT);
+                    fluidStack.grow(BUCKET_FLUID_AMOUNT);
+                    fluidTile.setFluid(fluidStack);
                 }
 
                 IChunk chunk = worldIn.getChunk(pos);

--- a/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
@@ -56,14 +56,15 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
      * @param maxFluidAmount the maximum fluid amount (in millibuckets. 1,000 = 1 bucket).
      * Must be >= 0.
      * @param renderFluid whether a fluid should be rendered for the client
-     * @param fluidPredicate a fluid validation predicate. Can hold fluids that test true.
-     * If null, an always true predicate will be used.
+     * @param fluidPredicate a fluid validation predicate. Can hold fluids that test true
      */
     public FluidHolderBlockComponent(int maxFluidAmount, boolean renderFluid, Predicate<Fluid> fluidPredicate) {
         Preconditions.checkArgument(maxFluidAmount >= 0, "Max fluid amount must be >= 0");
+        Preconditions.checkArgument(fluidPredicate != null, "Fluid predicate must not be null");
+
         this.maxFluidAmount = maxFluidAmount;
         this.renderFluid = renderFluid;
-        this.fluidPredicate = (fluidPredicate != null) ? fluidPredicate : Predicates.alwaysTrue();
+        this.fluidPredicate = fluidPredicate;
     }
 
     /**
@@ -75,7 +76,7 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
      * @param renderFluid whether a fluid should be rendered for the client
      */
     public FluidHolderBlockComponent(int maxFluidAmount, boolean renderFluid) {
-        this(maxFluidAmount, renderFluid, null);
+        this(maxFluidAmount, renderFluid, Predicates.alwaysTrue());
     }
 
     /**
@@ -84,8 +85,7 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
      *
      * @param maxFluidAmount the maximum fluid amount (in millibuckets. 1,000 = 1 bucket).
      * Must be >= 0.
-     * @param fluidPredicate a fluid validation predicate. Can hold fluids that test true.
-     * If null, an always true predicate will be used.
+     * @param fluidPredicate a fluid validation predicate. Can hold fluids that test true
      */
     public FluidHolderBlockComponent(int maxFluidAmount, Predicate<Fluid> fluidPredicate) {
         this(maxFluidAmount, true, fluidPredicate);
@@ -99,7 +99,7 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
      * Must be >= 0.
      */
     public FluidHolderBlockComponent(int maxFluidAmount) {
-        this(maxFluidAmount, true, null);
+        this(maxFluidAmount, true, Predicates.alwaysTrue());
     }
 
     /**

--- a/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
@@ -166,7 +166,7 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
                 if (!player.abilities.isCreativeMode) {
                     item.shrink(1);
                     if (!player.inventory.addItemStackToInventory(filledBucket)) {
-                        player.dropItem(filledBucket, false);
+                        player.dropItem(filledBucket, false); // Drop the bucket in the world if the inventory is already full
                     }
                 }
 

--- a/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
@@ -191,7 +191,7 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
 
             SoundEvent sound = fluid.getAttributes().getEmptySound(fluidStack);
             if (sound == null) {
-                sound = fluid.isIn(FluidTags.LAVA) ? SoundEvents.ITEM_BUCKET_EMPTY_LAVA : SoundEvents.ITEM_BUCKET_EMPTY;
+                sound = bucket.getFluid().isIn(FluidTags.LAVA) ? SoundEvents.ITEM_BUCKET_EMPTY_LAVA : SoundEvents.ITEM_BUCKET_EMPTY;
             }
 
             player.playSound(sound, 1.0F, 1.0F);

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/AllVertexBoundingBox.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/AllVertexBoundingBox.java
@@ -62,22 +62,22 @@ public class AllVertexBoundingBox {
      * be calculated based on the min and max points from the provided bounds. The created bounding
      * box will therefore match the bounds of the one provided.
      *
-     * @param minX the minimum x coordinate
-     * @param minY the minimum y coordinate
-     * @param minZ the minimum z coordinate
-     * @param maxX the maximum x coordinate
-     * @param maxY the maximum y coordinate
-     * @param maxZ the maximum z coordinate
+     * @param x the first x coordinate
+     * @param y the first y coordinate
+     * @param z the first z coordinate
+     * @param deltaX the second x coordinate
+     * @param deltaY the second y coordinate
+     * @param deltaZ the second z coordinate
      *
      * @return the newly created AllVertexBoundingBox
      */
-    public static AllVertexBoundingBox fromAABB(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
-        minX = Math.min(minX, maxX);
-        minY = Math.min(minY, maxY);
-        minZ = Math.min(minZ, maxZ);
-        maxX = Math.max(minX, maxX);
-        maxY = Math.max(minY, maxY);
-        maxZ = Math.max(minZ, maxZ);
+    public static AllVertexBoundingBox fromAABB(double x, double y, double z, double deltaX, double deltaY, double deltaZ) {
+        double minX = Math.min(x, deltaX);
+        double minY = Math.min(y, deltaY);
+        double minZ = Math.min(z, deltaZ);
+        double maxX = Math.max(x, deltaX);
+        double maxY = Math.max(y, deltaY);
+        double maxZ = Math.max(z, deltaZ);
 
         return create().frontBottomLeft(minX, minY, minZ)
                 .frontBottomRight(maxX, minY, minZ)

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/AllVertexBoundingBox.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/AllVertexBoundingBox.java
@@ -45,7 +45,7 @@ public class AllVertexBoundingBox {
     }
 
     /**
-     * Create an {@link AllVertexBoundingBox} based on an AxisAlignedBB. The missing vertexes will
+     * Create an {@link AllVertexBoundingBox} based on an AxisAlignedBB. The missing vertices will
      * be calculated based on the min and max points from the provided bounds. The created bounding
      * box will therefore match the bounds of the one provided.
      *
@@ -54,14 +54,39 @@ public class AllVertexBoundingBox {
      * @return the newly created AllVertexBoundingBox
      */
     public static AllVertexBoundingBox fromAABB(AxisAlignedBB bounds) {
-        return create().frontBottomLeft(bounds.minX, bounds.minY, bounds.minZ)
-                .frontBottomRight(bounds.maxX, bounds.minY, bounds.minZ)
-                .frontTopLeft(bounds.minX, bounds.maxY, bounds.minZ)
-                .frontTopRight(bounds.maxX, bounds.maxY, bounds.minZ)
-                .backBottomLeft(bounds.minX, bounds.minY, bounds.maxZ)
-                .backBottomRight(bounds.maxX, bounds.minY, bounds.maxZ)
-                .backTopLeft(bounds.minX, bounds.maxY, bounds.maxZ)
-                .backTopRight(bounds.maxX, bounds.maxY, bounds.maxZ).build();
+        return fromAABB(bounds.minX, bounds.minY, bounds.minZ, bounds.maxX, bounds.maxY, bounds.maxZ);
+    }
+
+    /**
+     * Create an {@link AllVertexBoundingBox} based on a set of coordinates. The missing vertices will
+     * be calculated based on the min and max points from the provided bounds. The created bounding
+     * box will therefore match the bounds of the one provided.
+     *
+     * @param minX the minimum x coordinate
+     * @param minY the minimum y coordinate
+     * @param minZ the minimum z coordinate
+     * @param maxX the maximum x coordinate
+     * @param maxY the maximum y coordinate
+     * @param maxZ the maximum z coordinate
+     *
+     * @return the newly created AllVertexBoundingBox
+     */
+    public static AllVertexBoundingBox fromAABB(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+        minX = Math.min(minX, maxX);
+        minY = Math.min(minY, maxY);
+        minZ = Math.min(minZ, maxZ);
+        maxX = Math.max(minX, maxX);
+        maxY = Math.max(minY, maxY);
+        maxZ = Math.max(minZ, maxZ);
+
+        return create().frontBottomLeft(minX, minY, minZ)
+                .frontBottomRight(maxX, minY, minZ)
+                .frontTopLeft(minX, maxY, minZ)
+                .frontTopRight(maxX, maxY, minZ)
+                .backBottomLeft(minX, minY, maxZ)
+                .backBottomRight(maxX, minY, maxZ)
+                .backTopLeft(minX, maxY, maxZ)
+                .backTopRight(maxX, maxY, maxZ).build();
     }
 
     /**

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/AllVertexBoundingBox.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/AllVertexBoundingBox.java
@@ -1,0 +1,242 @@
+package me.ferdz.placeableitems.client;
+
+import net.minecraft.client.renderer.Vector3d;
+import net.minecraft.util.math.AxisAlignedBB;
+
+/**
+ * Represents a box defined by 8 points in the world. Unlike {@link AxisAlignedBB}s, points
+ * are not validated. Therefore, caution must be taken when creating instances of this box
+ * as some points may not be properly named according to this class' member methods. The
+ * methods are named according to their position in the world relative to the player when facing
+ * the bounding box.
+ *
+ * @author Parker Hawke - Choco
+ */
+public class AllVertexBoundingBox {
+
+    private final Vector3d frontBottomLeft, frontBottomRight;
+    private final Vector3d frontTopLeft, frontTopRight;
+
+    private final Vector3d backBottomLeft, backBottomRight;
+    private final Vector3d backTopLeft, backTopRight;
+
+    /**
+     * Create an AllVertexBoundingBox with all 8 vertexes. It is recommended that a builder be
+     * used instead. See {@link #create()} or {@link #fromAABB(AxisAlignedBB)}.
+     *
+     * @param frontBottomLeft the front, bottom left vertex
+     * @param frontBottomRight the front, bottom right vertex
+     * @param frontTopLeft the front, top left vertex
+     * @param frontTopRight the front, top right vertex
+     * @param backBottomLeft the back, bottom left vertex
+     * @param backBottomRight the back, bottom right vertex
+     * @param backTopLeft the back, top left vertex
+     * @param backTopRight the back, top right vertex
+     */
+    public AllVertexBoundingBox(Vector3d frontBottomLeft, Vector3d frontBottomRight, Vector3d frontTopLeft, Vector3d frontTopRight, Vector3d backBottomLeft, Vector3d backBottomRight, Vector3d backTopLeft, Vector3d backTopRight) {
+        this.frontBottomLeft = frontBottomLeft;
+        this.frontBottomRight = frontBottomRight;
+        this.frontTopLeft = frontTopLeft;
+        this.frontTopRight = frontTopRight;
+        this.backBottomLeft = backBottomLeft;
+        this.backBottomRight = backBottomRight;
+        this.backTopLeft = backTopLeft;
+        this.backTopRight = backTopRight;
+    }
+
+    /**
+     * Create an {@link AllVertexBoundingBox} based on an AxisAlignedBB. The missing vertexes will
+     * be calculated based on the min and max points from the provided bounds. The created bounding
+     * box will therefore match the bounds of the one provided.
+     *
+     * @param bounds the bounding box from which to create an AllVertexBoundingBox
+     *
+     * @return the newly created AllVertexBoundingBox
+     */
+    public static AllVertexBoundingBox fromAABB(AxisAlignedBB bounds) {
+        return create().frontBottomLeft(bounds.minX, bounds.minY, bounds.minZ)
+                .frontBottomRight(bounds.maxX, bounds.minY, bounds.minZ)
+                .frontTopLeft(bounds.minX, bounds.maxY, bounds.minZ)
+                .frontTopRight(bounds.maxX, bounds.maxY, bounds.minZ)
+                .backBottomLeft(bounds.minX, bounds.minY, bounds.maxZ)
+                .backBottomRight(bounds.maxX, bounds.minY, bounds.maxZ)
+                .backTopLeft(bounds.minX, bounds.maxY, bounds.maxZ)
+                .backTopRight(bounds.maxX, bounds.maxY, bounds.maxZ).build();
+    }
+
+    /**
+     * Get a builder instance to create an {@link AllVertexBoundingBox}.
+     *
+     * @return the builder instance
+     */
+    public static AllVertexBoundingBox.Builder create() {
+        return new AllVertexBoundingBox.Builder();
+    }
+
+    /**
+     * Get the front, bottom left vertex of this bounding box.
+     *
+     * @return the front, bottom left vertex
+     */
+    public Vector3d getFrontBottomLeft() {
+        return frontBottomLeft;
+    }
+
+    /**
+     * Get the front, bottom right vertex of this bounding box.
+     *
+     * @return the front, bottom right vertex
+     */
+    public Vector3d getFrontBottomRight() {
+        return frontBottomRight;
+    }
+
+    /**
+     * Get the front, top left vertex of this bounding box.
+     *
+     * @return the front, top left vertex
+     */
+    public Vector3d getFrontTopLeft() {
+        return frontTopLeft;
+    }
+
+    /**
+     * Get the front, top right vertex of this bounding box.
+     *
+     * @return the front, top right vertex
+     */
+    public Vector3d getFrontTopRight() {
+        return frontTopRight;
+    }
+
+    /**
+     * Get the back, bottom left vertex of this bounding box.
+     *
+     * @return the back, bottom left vertex
+     */
+    public Vector3d getBackBottomLeft() {
+        return backBottomLeft;
+    }
+
+    /**
+     * Get the back, bottom right vertex of this bounding box.
+     *
+     * @return the back, bottom right vertex
+     */
+    public Vector3d getBackBottomRight() {
+        return backBottomRight;
+    }
+
+    /**
+     * Get the back, top left vertex of this bounding box.
+     *
+     * @return the back, top left vertex
+     */
+    public Vector3d getBackTopLeft() {
+        return backTopLeft;
+    }
+
+    /**
+     * Get the back, top right vertex of this bounding box.
+     *
+     * @return the back, top right vertex
+     */
+    public Vector3d getBackTopRight() {
+        return backTopRight;
+    }
+
+    /**
+     * Rotate this bounding box clockwise around the y axis.
+     *
+     * @param radians the amount (in radians) by which to rotate this bounding box.
+     *
+     * @return a new {@link AllVertexBoundingBox} rotated clockwise by the specified radians
+     */
+    public AllVertexBoundingBox rotateAroundY(double radians) {
+        double sin = Math.sin(radians), cos = Math.cos(radians);
+
+        double frontBottomLeftRotatedX = (frontBottomLeft.x * cos) + (frontBottomLeft.z * sin);
+        double frontBottomLeftRotatedZ = (-frontBottomLeft.x * sin) + (frontBottomLeft.z * cos);
+        double frontBottomRightRotatedX = (frontBottomRight.x * cos) + (frontBottomRight.z * sin);
+        double frontBottomRightRotatedZ = (-frontBottomRight.x * sin) + (frontBottomRight.z * cos);
+        double frontTopLeftRotatedX = (frontTopLeft.x * cos) + (frontTopLeft.z * sin);
+        double frontTopLeftRotatedZ = (-frontTopLeft.x * sin) + (frontTopLeft.z * cos);
+        double frontTopRightRotatedX = (frontTopRight.x * cos) + (frontTopRight.z * sin);
+        double frontTopRightRotatedZ = (-frontTopRight.x * sin) + (frontTopRight.z * cos);
+
+        double backBottomLeftRotatedX = (backBottomLeft.x * cos) + (backBottomLeft.z * sin);
+        double backBottomLeftRotatedZ = (-backBottomLeft.x * sin) + (backBottomLeft.z * cos);
+        double backBottomRightRotatedX = (backBottomRight.x * cos) + (backBottomRight.z * sin);
+        double backBottomRightRotatedZ = (-backBottomRight.x * sin) + (backBottomRight.z * cos);
+        double backTopLeftRotatedX = (backTopLeft.x * cos) + (backTopLeft.z * sin);
+        double backTopLeftRotatedZ = (-backTopLeft.x * sin) + (backTopLeft.z * cos);
+        double backTopRightRotatedX = (backTopRight.x * cos) + (backTopRight.z * sin);
+        double backTopRightRotatedZ = (-backTopRight.x * sin) + (backTopRight.z * cos);
+
+        return create().frontBottomLeft(frontBottomLeftRotatedX, frontBottomLeft.y, frontBottomLeftRotatedZ)
+                .frontBottomRight(frontBottomRightRotatedX, frontBottomRight.y, frontBottomRightRotatedZ)
+                .frontTopLeft(frontTopLeftRotatedX, frontTopLeft.y, frontTopLeftRotatedZ)
+                .frontTopRight(frontTopRightRotatedX, frontTopRight.y, frontTopRightRotatedZ)
+                .backBottomLeft(backBottomLeftRotatedX, backBottomLeft.y, backBottomLeftRotatedZ)
+                .backBottomRight(backBottomRightRotatedX, backBottomRight.y, backBottomRightRotatedZ)
+                .backTopLeft(backTopLeftRotatedX, backTopLeft.y, backTopLeftRotatedZ)
+                .backTopRight(backTopRightRotatedX, backTopRight.y, backTopRightRotatedZ).build();
+    }
+
+    public static class Builder {
+
+        private Vector3d frontBottomLeft, frontBottomRight;
+        private Vector3d frontTopLeft, frontTopRight;
+
+        private Vector3d backBottomLeft, backBottomRight;
+        private Vector3d backTopLeft, backTopRight;
+
+        private Builder() { }
+
+        public Builder frontBottomLeft(double x, double y, double z) {
+            this.frontBottomLeft = new Vector3d(x, y, z);
+            return this;
+        }
+
+        public Builder frontBottomRight(double x, double y, double z) {
+            this.frontBottomRight = new Vector3d(x, y, z);
+            return this;
+        }
+
+        public Builder frontTopLeft(double x, double y, double z) {
+            this.frontTopLeft = new Vector3d(x, y, z);
+            return this;
+        }
+
+        public Builder frontTopRight(double x, double y, double z) {
+            this.frontTopRight = new Vector3d(x, y, z);
+            return this;
+        }
+
+        public Builder backBottomLeft(double x, double y, double z) {
+            this.backBottomLeft = new Vector3d(x, y, z);
+            return this;
+        }
+
+        public Builder backBottomRight(double x, double y, double z) {
+            this.backBottomRight = new Vector3d(x, y, z);
+            return this;
+        }
+
+        public Builder backTopLeft(double x, double y, double z) {
+            this.backTopLeft = new Vector3d(x, y, z);
+            return this;
+        }
+
+        public Builder backTopRight(double x, double y, double z) {
+            this.backTopRight = new Vector3d(x, y, z);
+            return this;
+        }
+
+        public AllVertexBoundingBox build() {
+            return new AllVertexBoundingBox(frontBottomLeft, frontBottomRight, frontTopLeft, frontTopRight, backBottomLeft, backBottomRight, backTopLeft, backTopRight);
+        }
+
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/ClientListener.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/ClientListener.java
@@ -5,13 +5,15 @@ import me.ferdz.placeableitems.client.renderer.tileentity.FluidHolderRenderer;
 import me.ferdz.placeableitems.init.PlaceableItemsBlockRegistry;
 import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
 
+import net.minecraft.util.LazyLoadBase;
+
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 
 public final class ClientListener {
 
-    private static ClientListener instance;
+    private static final LazyLoadBase<ClientListener> INSTANCE = new LazyLoadBase<>(ClientListener::new);
 
     private ClientListener() { }
 
@@ -23,7 +25,7 @@ public final class ClientListener {
     }
 
     public static ClientListener get() {
-        return (instance != null) ? instance : (instance = new ClientListener());
+        return INSTANCE.getValue();
     }
 
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/ClientListener.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/ClientListener.java
@@ -1,0 +1,29 @@
+package me.ferdz.placeableitems.client;
+
+import me.ferdz.placeableitems.client.model.GlassBottleFluidModel;
+import me.ferdz.placeableitems.client.renderer.tileentity.FluidHolderRenderer;
+import me.ferdz.placeableitems.init.PlaceableItemsBlockRegistry;
+import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
+
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+
+public final class ClientListener {
+
+    private static ClientListener instance;
+
+    private ClientListener() { }
+
+    @SubscribeEvent // Fluid models should be binded here:
+    void onClientSetup(@SuppressWarnings("unused") FMLClientSetupEvent event) {
+        ClientRegistry.bindTileEntitySpecialRenderer(FluidHolderTileEntity.class, new FluidHolderRenderer()
+                .bind(PlaceableItemsBlockRegistry.GLASS_BOTTLE, new GlassBottleFluidModel())
+        );
+    }
+
+    public static ClientListener get() {
+        return (instance != null) ? instance : (instance = new ClientListener());
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
@@ -39,21 +39,21 @@ public abstract class FluidModel {
     private final Map<BlockState, AllVertexBoundingBox> renderCache = new IdentityHashMap<>();
 
     /**
-     * Get the rendering bounds for this model from the render cache (if present) and optionally
-     * recalculate the cached model. If a model is not present, it will be calculated and cached.
+     * Get the rendering bounds for this model from the render cache (if present). If a model is not
+     * present, it will be calculated and cached. Additionally, the model will be recalculated if the
+     * result of {@link #shouldRecalculate(BlockState)} is true.
      *
      * @param state the state whose model to retrieve
-     * @param recalculate whether or not to recalculate the model
      *
      * @return the rendering bounds
      */
-    public final AllVertexBoundingBox getRenderBounds(BlockState state, boolean recalculate) {
-        return recalculate ? renderCache.compute(state, (s, existing) -> calculateRenderBounds(s)) : renderCache.computeIfAbsent(state, this::calculateRenderBounds);
+    public final AllVertexBoundingBox getRenderBounds(BlockState state) {
+        return shouldRecalculate(state) ? renderCache.compute(state, (s, existing) -> calculateRenderBounds(s)) : renderCache.computeIfAbsent(state, this::calculateRenderBounds);
     }
 
     /**
      * Calculate the rendering bounds for this model. This method does not account for cached models
-     * and should be used sparingly. Method callers should use {@link #getRenderBounds(BlockState, boolean)}
+     * and should be used sparingly. Method callers should use {@link #getRenderBounds(BlockState)}
      * instead to ensure a cached value is retrieved instead.
      * <p>
      * Implementations should consider the state's rotation and other states the block may have. Each

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
@@ -1,0 +1,133 @@
+package me.ferdz.placeableitems.client.model;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import me.ferdz.placeableitems.block.component.impl.FluidHolderBlockComponent;
+import me.ferdz.placeableitems.client.AllVertexBoundingBox;
+import me.ferdz.placeableitems.client.renderer.tileentity.FluidHolderRenderer;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.client.renderer.Vector3d;
+import net.minecraft.util.Direction;
+
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+
+/**
+ * Represents a model definition for a fluid renderable in a {@link FluidHolderBlockComponent}.
+ * Models should cache model data where possible (including rotation points and render bounds)
+ * and return them where necessary.
+ * <p>
+ * All states will have their render bounds cached and may be
+ * recalculated at any time such that {@link #shouldRecalculate(BlockState)} returns true. Please
+ * be cautious when returning true in the aforementioned method such that any computationally-expensive
+ * calculations will be re-run (however {@link #calculateRenderBounds(BlockState)} is implemented).
+ * <p>
+ * FluidModel implementations should be registered in a {@link FMLClientSetupEvent} with the
+ * {@link FluidHolderRenderer#bind(me.ferdz.placeableitems.block.PlaceableItemsBlock, FluidModel)}
+ * method. If a {@link FluidHolderBlockComponent#shouldRenderFluid()} returns true but has no registered
+ * FluidModel, an exception will be thrown an the client will crash.
+ *
+ * @see FluidHolderRenderer#bind(me.ferdz.placeableitems.block.PlaceableItemsBlock, FluidModel)
+ *
+ * @author Parker Hawke - Choco
+ */
+public abstract class FluidModel {
+
+    private static final Vector3d ZEROED_OFFSET = new Vector3d(0.0D, 0.0D, 0.0D);
+
+    private final Map<BlockState, AllVertexBoundingBox> renderCache = new IdentityHashMap<>();
+
+    /**
+     * Get the rendering bounds for this model from the render cache (if present) and optionally
+     * recalculate the cached model. If a model is not present, it will be calculated and cached.
+     *
+     * @param state the state whose model to retrieve
+     * @param recalculate whether or not to recalculate the model
+     *
+     * @return the rendering bounds
+     */
+    public final AllVertexBoundingBox getRenderBounds(BlockState state, boolean recalculate) {
+        return recalculate ? renderCache.compute(state, (s, existing) -> calculateRenderBounds(s)) : renderCache.computeIfAbsent(state, this::calculateRenderBounds);
+    }
+
+    /**
+     * Calculate the rendering bounds for this model. This method does not account for cached models
+     * and should be used sparingly. Method callers should use {@link #getRenderBounds(BlockState, boolean)}
+     * instead to ensure a cached value is retrieved instead.
+     * <p>
+     * Implementations should consider the state's rotation and other states the block may have. Each
+     * unique state will be cached in the model's render cache. This method will only be called such that
+     * no model has yet been cached for the provided state, or {@link #shouldRecalculate(BlockState)}
+     * returns true.
+     * <p>
+     * These bounds support negative values and will be relative to {@link #getRotationPoint(BlockState)}.
+     *
+     * @param state the state whose render bounds to calculate
+     *
+     * @return the rendering bounds
+     */
+    public abstract AllVertexBoundingBox calculateRenderBounds(BlockState state);
+
+    /**
+     * Check whether or not the provided state has been cached.
+     *
+     * @param state the state to check
+     *
+     * @return true if cached, false otherwise
+     */
+    public boolean isCached(BlockState state) {
+        return renderCache.containsKey(state);
+    }
+
+    /**
+     * Clear the render cache for this model. Models for each unique state will be lazily recalculated when
+     * required.
+     */
+    public void clearRenderCache() {
+        this.renderCache.clear();
+    }
+
+    /**
+     * Check whether or not a quad should be rendered according to the specified direction
+     *
+     * @param state the state to check
+     * @param direction the direction to check
+     *
+     * @return true if the direction should be rendered, false otherwise
+     */
+    public boolean shouldRender(BlockState state, Direction direction) {
+        return true;
+    }
+
+    /**
+     * Get a pixel-scaled vector (values ranging from 0 - 16) for which this model may be rotated.
+     * {@link #calculateRenderBounds(BlockState)} will be rendered relative to this point. This value defaults
+     * to (0, 0, 0), the pixel relative to the origin of the block
+     *
+     * @param state the state whose rotation point to get
+     *
+     * @return the rotation point
+     */
+    public Vector3d getRotationPoint(BlockState state) {
+        return ZEROED_OFFSET;
+    }
+
+    /**
+     * Check whether or not the render bounds for the specified state should be recalculated. The
+     * result of this method is considered by the {@link FluidHolderRenderer} when fetching a cached
+     * model.
+     * <p>
+     * Caution should be had when overiding this method. Such that this method returns true, rendering
+     * bounds will be calculated for this state and {@link #calculateRenderBounds(BlockState)} will be
+     * invoked.
+     *
+     * @param state the state to check
+     *
+     * @return true if the model should be recalculated
+     */
+    public boolean shouldRecalculate(BlockState state) {
+        return false;
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
@@ -34,7 +34,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
  */
 public abstract class FluidModel {
 
-    private static final Vector3d ZEROED_OFFSET = new Vector3d(0.0D, 0.0D, 0.0D);
+    private static final Vector3d ZEROED_ORIGIN = new Vector3d(0.0D, 0.0D, 0.0D);
 
     private final Map<BlockState, AllVertexBoundingBox> renderCache = new IdentityHashMap<>();
 
@@ -61,7 +61,7 @@ public abstract class FluidModel {
      * no model has yet been cached for the provided state, or {@link #shouldRecalculate(BlockState)}
      * returns true.
      * <p>
-     * These bounds support negative values and will be relative to {@link #getRotationPoint(BlockState)}.
+     * These bounds support negative values and will be relative to {@link #getOrigin(BlockState)}.
      *
      * @param state the state whose render bounds to calculate
      *
@@ -101,16 +101,18 @@ public abstract class FluidModel {
     }
 
     /**
-     * Get a pixel-scaled vector (values ranging from 0 - 16) for which this model may be rotated.
+     * Get a pixel-scaled vector (values ranging from 0 - 16) for which this model may be rotated and positioned.
      * {@link #calculateRenderBounds(BlockState)} will be rendered relative to this point. This value defaults
-     * to (0, 0, 0), the pixel relative to the origin of the block
+     * to (0, 0, 0), the pixel positioned at the origin of the block relative to the floored block coordinates.
+     * <p>
+     * The point of origin will offset the rendering position and determine the point of rotation for this model.
      *
-     * @param state the state whose rotation point to get
+     * @param state the state whose origin point to get
      *
      * @return the rotation point
      */
-    public Vector3d getRotationPoint(BlockState state) {
-        return ZEROED_OFFSET;
+    public Vector3d getOrigin(BlockState state) {
+        return ZEROED_ORIGIN;
     }
 
     /**

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
@@ -34,8 +34,6 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
  */
 public abstract class FluidModel {
 
-    private static final Vector3d ZEROED_ORIGIN = new Vector3d(0.0D, 0.0D, 0.0D);
-
     private final Map<BlockState, AllVertexBoundingBox> renderCache = new IdentityHashMap<>();
 
     /**
@@ -102,8 +100,8 @@ public abstract class FluidModel {
 
     /**
      * Get a pixel-scaled vector (values ranging from 0 - 16) for which this model may be rotated and positioned.
-     * {@link #calculateRenderBounds(BlockState)} will be rendered relative to this point. This value defaults
-     * to (0, 0, 0), the pixel positioned at the origin of the block relative to the floored block coordinates.
+     * {@link #calculateRenderBounds(BlockState)} will be rendered relative to this point. (0, 0, 0) is defined
+     * as the pixel positioned at the origin of the block relative to the floored block coordinates.
      * <p>
      * The point of origin will offset the rendering position and determine the point of rotation for this model.
      *
@@ -111,9 +109,7 @@ public abstract class FluidModel {
      *
      * @return the rotation point
      */
-    public Vector3d getOrigin(BlockState state) {
-        return ZEROED_ORIGIN;
-    }
+    public abstract Vector3d getOrigin(BlockState state);
 
     /**
      * Check whether or not the render bounds for the specified state should be recalculated. The

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
@@ -16,8 +16,8 @@ import net.minecraft.util.Direction;
  */
 public class GlassBottleFluidModel extends FluidModel {
 
-    private static final Vector3d ROTATION_POINT = new Vector3d(8.0D, 1.0D, 8.0D);
-    private static final Vector3d UP_ROTATION_POINT = new Vector3d(8.0D, 5.0D, 8.0D);
+    private static final Vector3d ORIGIN = new Vector3d(8.0D, 1.0D, 8.0D);
+    private static final Vector3d UP_ORIGIN = new Vector3d(8.0D, 5.0D, 8.0D);
 
     private static final AllVertexBoundingBox BOUNDS = AllVertexBoundingBox.fromAABB(-2.5 / 16.0, 0.0D, -2.5 / 16.0, 2.5 / 16.0, 4 / 16.0, 2.5 / 16.0);
 
@@ -27,8 +27,8 @@ public class GlassBottleFluidModel extends FluidModel {
     }
 
     @Override
-    public Vector3d getRotationPoint(BlockState state) {
-        return state.get(BiPositionBlockComponent.UP) ? UP_ROTATION_POINT : ROTATION_POINT;
+    public Vector3d getOrigin(BlockState state) {
+        return state.get(BiPositionBlockComponent.UP) ? UP_ORIGIN : ORIGIN;
     }
 
     @Override

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
@@ -7,6 +7,7 @@ import me.ferdz.placeableitems.init.PlaceableItemsBlockRegistry;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.Vector3d;
+import net.minecraft.util.Direction;
 import net.minecraft.util.math.AxisAlignedBB;
 
 /**
@@ -19,7 +20,7 @@ public class GlassBottleFluidModel extends FluidModel {
     private static final Vector3d ROTATION_POINT = new Vector3d(8.0D, 1.0D, 8.0D);
     private static final Vector3d UP_ROTATION_POINT = new Vector3d(8.0D, 5.0D, 8.0D);
 
-    private static final AllVertexBoundingBox BOUNDS = AllVertexBoundingBox.fromAABB(new AxisAlignedBB(-2.5F / 16F, 0.001F / 16F, -2.5F / 16F, 2.5F / 16F, 4F / 16F, 2.5F / 16F));
+    private static final AllVertexBoundingBox BOUNDS = AllVertexBoundingBox.fromAABB(new AxisAlignedBB(-2.5F / 16F, 0F / 16F, -2.5F / 16F, 2.5F / 16F, 4F / 16F, 2.5F / 16F));
 
     @Override
     public AllVertexBoundingBox calculateRenderBounds(BlockState state) {
@@ -29,6 +30,11 @@ public class GlassBottleFluidModel extends FluidModel {
     @Override
     public Vector3d getRotationPoint(BlockState state) {
         return state.get(BiPositionBlockComponent.UP) ? UP_ROTATION_POINT : ROTATION_POINT;
+    }
+
+    @Override
+    public boolean shouldRender(BlockState state, Direction direction) {
+        return direction != Direction.DOWN;
     }
 
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
@@ -8,7 +8,6 @@ import me.ferdz.placeableitems.init.PlaceableItemsBlockRegistry;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.Vector3d;
 import net.minecraft.util.Direction;
-import net.minecraft.util.math.AxisAlignedBB;
 
 /**
  * An implementation of {@link FluidModel} for the {@link PlaceableItemsBlockRegistry#GLASS_BOTTLE}.
@@ -20,7 +19,7 @@ public class GlassBottleFluidModel extends FluidModel {
     private static final Vector3d ROTATION_POINT = new Vector3d(8.0D, 1.0D, 8.0D);
     private static final Vector3d UP_ROTATION_POINT = new Vector3d(8.0D, 5.0D, 8.0D);
 
-    private static final AllVertexBoundingBox BOUNDS = AllVertexBoundingBox.fromAABB(new AxisAlignedBB(-2.5F / 16F, 0F / 16F, -2.5F / 16F, 2.5F / 16F, 4F / 16F, 2.5F / 16F));
+    private static final AllVertexBoundingBox BOUNDS = AllVertexBoundingBox.fromAABB(-2.5 / 16.0, 0.0D, -2.5 / 16.0, 2.5 / 16.0, 4 / 16.0, 2.5 / 16.0);
 
     @Override
     public AllVertexBoundingBox calculateRenderBounds(BlockState state) {

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
@@ -1,0 +1,34 @@
+package me.ferdz.placeableitems.client.model;
+
+import me.ferdz.placeableitems.block.PlaceableItemsBlock;
+import me.ferdz.placeableitems.block.component.impl.BiPositionBlockComponent;
+import me.ferdz.placeableitems.client.AllVertexBoundingBox;
+import me.ferdz.placeableitems.init.PlaceableItemsBlockRegistry;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.client.renderer.Vector3d;
+import net.minecraft.util.math.AxisAlignedBB;
+
+/**
+ * An implementation of {@link FluidModel} for the {@link PlaceableItemsBlockRegistry#GLASS_BOTTLE}.
+ *
+ * @author Parker Hawke - Choco
+ */
+public class GlassBottleFluidModel extends FluidModel {
+
+    private static final Vector3d ROTATION_POINT = new Vector3d(8.0D, 1.0D, 8.0D);
+    private static final Vector3d UP_ROTATION_POINT = new Vector3d(8.0D, 5.0D, 8.0D);
+
+    private static final AllVertexBoundingBox BOUNDS = AllVertexBoundingBox.fromAABB(new AxisAlignedBB(-2.5F / 16F, 0.001F / 16F, -2.5F / 16F, 2.5F / 16F, 4F / 16F, 2.5F / 16F));
+
+    @Override
+    public AllVertexBoundingBox calculateRenderBounds(BlockState state) {
+        return BOUNDS.rotateAroundY(Math.toRadians((-state.get(PlaceableItemsBlock.ROTATION) * 360F / 16.0F)));
+    }
+
+    @Override
+    public Vector3d getRotationPoint(BlockState state) {
+        return state.get(BiPositionBlockComponent.UP) ? UP_ROTATION_POINT : ROTATION_POINT;
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/network/ClientPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/network/ClientPacketHandler.java
@@ -1,0 +1,48 @@
+package me.ferdz.placeableitems.client.network;
+
+import java.util.function.Supplier;
+
+import me.ferdz.placeableitems.network.SUpdateFluidHolderPacket;
+import me.ferdz.placeableitems.network.handler.AnonymousPacketHandler;
+import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.LazyLoadBase;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+
+import net.minecraftforge.fml.network.NetworkEvent;
+
+public final class ClientPacketHandler implements AnonymousPacketHandler {
+
+    private static final LazyLoadBase<AnonymousPacketHandler> INSTANCE  = new LazyLoadBase<>(() -> new ClientPacketHandler());
+
+    private ClientPacketHandler() { }
+
+    @Override
+    public void handleUpdateFluidHolder(SUpdateFluidHolderPacket packet, Supplier<NetworkEvent.Context> ctx) {
+        NetworkEvent.Context context = ctx.get();
+
+        context.enqueueWork(() -> {
+            World world = Minecraft.getInstance().world;
+            if (!world.getChunkProvider().isChunkLoaded(new ChunkPos(packet.getTilePos()))) {
+                return;
+            }
+
+            TileEntity tile = world.getTileEntity(packet.getTilePos());
+            if (!(tile instanceof FluidHolderTileEntity)) {
+                return;
+            }
+
+            ((FluidHolderTileEntity) tile).setFluid(packet.getFluidStack());
+        });
+
+        context.setPacketHandled(true);
+    }
+
+    public static AnonymousPacketHandler get() {
+        return INSTANCE.getValue();
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/network/ClientPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/network/ClientPacketHandler.java
@@ -14,6 +14,11 @@ import net.minecraft.world.World;
 
 import net.minecraftforge.fml.network.NetworkEvent;
 
+/**
+ * Client-sided implementation of {@link AnonymousPacketHandler}
+ *
+ * @author Parker Hawke - Choco
+ */
 public final class ClientPacketHandler implements AnonymousPacketHandler {
 
     private static final LazyLoadBase<AnonymousPacketHandler> INSTANCE  = new LazyLoadBase<>(() -> new ClientPacketHandler());

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
@@ -30,7 +30,7 @@ import net.minecraftforge.fluids.FluidStack;
  * Fluid holders should bind {@link FluidModel} implementations to each registered renderer
  * instance using {@link #bind(PlaceableItemsBlock, FluidModel)}. If a
  * {@link FluidHolderBlockComponent#shouldRenderFluid()} returns true but has no registeredFluidModel,
- * an exception will be thrown an the client will crash.
+ * an exception will be thrown and the client will crash.
  *
  * @author Parker Hawke - Choco
  */

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
@@ -76,7 +76,7 @@ public class FluidHolderRenderer extends TileEntityRendererFast<FluidHolderTileE
         float blue = (color & 0xFF) / 255F;
 
         BlockPos pos = tile.getPos();
-        AllVertexBoundingBox bounds = model.getRenderBounds(state, model.shouldRecalculate(state));
+        AllVertexBoundingBox bounds = model.getRenderBounds(state);
 
         if (model.shouldRender(state, Direction.DOWN)) {
             int downCombined = getWorld().getCombinedLight(pos.down(), 0);

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
@@ -1,0 +1,184 @@
+package me.ferdz.placeableitems.client.renderer.tileentity;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import com.google.common.base.Preconditions;
+
+import me.ferdz.placeableitems.block.PlaceableItemsBlock;
+import me.ferdz.placeableitems.block.component.IBlockComponent;
+import me.ferdz.placeableitems.block.component.impl.FluidHolderBlockComponent;
+import me.ferdz.placeableitems.client.AllVertexBoundingBox;
+import me.ferdz.placeableitems.client.model.FluidModel;
+import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.Vector3d;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+
+import net.minecraftforge.client.model.animation.TileEntityRendererFast;
+import net.minecraftforge.fluids.FluidStack;
+
+/**
+ * A fast tile entity renderer implementation for {@link FluidHolderTileEntity} instances.
+ * Fluid holders should bind {@link FluidModel} implementations to each registered renderer
+ * instance using {@link #bind(PlaceableItemsBlock, FluidModel)}. If a
+ * {@link FluidHolderBlockComponent#shouldRenderFluid()} returns true but has no registeredFluidModel,
+ * an exception will be thrown an the client will crash.
+ *
+ * @author Parker Hawke - Choco
+ */
+public class FluidHolderRenderer extends TileEntityRendererFast<FluidHolderTileEntity> {
+
+    private final Map<PlaceableItemsBlock, FluidModel> fluidModels = new IdentityHashMap<>();
+
+    @Override
+    public void renderTileEntityFast(FluidHolderTileEntity tile, double x, double y, double z, float partialTicks, int destroyStage, BufferBuilder buffer) {
+        FluidStack fluidStack = tile.getFluid();
+        if (fluidStack.isEmpty()) {
+            return;
+        }
+
+        BlockState state = tile.getBlockState();
+        Block block = state.getBlock();
+        if (!(block instanceof PlaceableItemsBlock)) {
+            return;
+        }
+
+        FluidHolderBlockComponent fluidComponent = getFluidHolderBlockComponent((PlaceableItemsBlock) block);
+        Preconditions.checkState(fluidComponent != null, "FluidHolderTileEntity does not have a FluidHolderBlockComponent. This is impossible.");
+        if (!fluidComponent.shouldRenderFluid()) {
+            return;
+        }
+
+        FluidModel model = this.fluidModels.get(block);
+        Preconditions.checkState(model != null, "Missing model binding for FluidHolderTileEntity (" + tile.getClass().getName() + ")");
+
+        Vector3d rotationPoint = model.getRotationPoint(state);
+        buffer.setTranslation(x + (rotationPoint.x / 16F), y + (rotationPoint.y / 16F), z + (rotationPoint.z / 16F));
+
+        // Render the fluid
+        Fluid fluid = fluidStack.getFluid();
+        TextureAtlasSprite still = Minecraft.getInstance().getTextureMap().getAtlasSprite(fluid.getAttributes().getStill(fluidStack).toString());
+        float u1 = still.getMinU(), u2 = still.getMaxU();
+        float v1 = still.getMinV(), v2 = still.getMaxV();
+
+        int color = fluid.getAttributes().getColor(fluidStack);
+        float alpha = (color >> 24 & 0xFF) / 255F;
+        float red = (color >> 16 & 0xFF) / 255F;
+        float green = (color >> 8 & 0xFF) / 255F;
+        float blue = (color & 0xFF) / 255F;
+
+        BlockPos pos = tile.getPos();
+        AllVertexBoundingBox bounds = model.getRenderBounds(state, model.shouldRecalculate(state));
+
+        if (model.shouldRender(state, Direction.DOWN)) {
+            int downCombined = getWorld().getCombinedLight(pos.down(), 0);
+            int downLMa = downCombined >> 16 & 65535;
+            int downLMb = downCombined & 65535;
+
+            bufferPos(buffer, bounds.getBackBottomLeft()).color(red, green, blue, alpha).tex(u1, v2).lightmap(downLMa, downLMb).endVertex();
+            bufferPos(buffer, bounds.getFrontBottomLeft()).color(red, green, blue, alpha).tex(u1, v1).lightmap(downLMa, downLMb).endVertex();
+            bufferPos(buffer, bounds.getFrontBottomRight()).color(red, green, blue, alpha).tex(u2, v1).lightmap(downLMa, downLMb).endVertex();
+            bufferPos(buffer, bounds.getBackBottomRight()).color(red, green, blue, alpha).tex(u2, v2).lightmap(downLMa, downLMb).endVertex();
+        }
+
+        if (model.shouldRender(state, Direction.UP)) {
+            int upCombined = getWorld().getCombinedLight(pos.up(), 0);
+            int upLMa = upCombined >> 16 & 65535;
+            int upLMb = upCombined & 65535;
+
+            bufferPos(buffer, bounds.getBackTopLeft()).color(red, green, blue, alpha).tex(u1, v2).lightmap(upLMa, upLMb).endVertex();
+            bufferPos(buffer, bounds.getFrontTopLeft()).color(red, green, blue, alpha).tex(u1, v1).lightmap(upLMa, upLMb).endVertex();
+            bufferPos(buffer, bounds.getFrontTopRight()).color(red, green, blue, alpha).tex(u2, v1).lightmap(upLMa, upLMb).endVertex();
+            bufferPos(buffer, bounds.getBackTopRight()).color(red, green, blue, alpha).tex(u2, v2).lightmap(upLMa, upLMb).endVertex();
+        }
+
+        if (model.shouldRender(state, Direction.NORTH)) {
+            int northCombined = getWorld().getCombinedLight(pos.north(), 0);
+            int northLMa = northCombined >> 16 & 65535;
+            int northLMb = northCombined & 65535;
+
+            bufferPos(buffer, bounds.getFrontBottomLeft()).color(red, green, blue, alpha).tex(u1, v1).lightmap(northLMa, northLMb).endVertex();
+            bufferPos(buffer, bounds.getFrontTopLeft()).color(red, green, blue, alpha).tex(u1, v2).lightmap(northLMa, northLMb).endVertex();
+            bufferPos(buffer, bounds.getFrontTopRight()).color(red, green, blue, alpha).tex(u2, v2).lightmap(northLMa, northLMb).endVertex();
+            bufferPos(buffer, bounds.getFrontBottomRight()).color(red, green, blue, alpha).tex(u2, v1).lightmap(northLMa, northLMb).endVertex();
+        }
+
+        if (model.shouldRender(state, Direction.SOUTH)) {
+            int southCombined = getWorld().getCombinedLight(pos.south(), 0);
+            int southLMa = southCombined >> 16 & 65535;
+            int southLMb = southCombined & 65535;
+
+            bufferPos(buffer, bounds.getBackBottomRight()).color(red, green, blue, alpha).tex(u2, v1).lightmap(southLMa, southLMb).endVertex();
+            bufferPos(buffer, bounds.getBackTopRight()).color(red, green, blue, alpha).tex(u2, v2).lightmap(southLMa, southLMb).endVertex();
+            bufferPos(buffer, bounds.getBackTopLeft()).color(red, green, blue, alpha).tex(u1, v2).lightmap(southLMa, southLMb).endVertex();
+            bufferPos(buffer, bounds.getBackBottomLeft()).color(red, green, blue, alpha).tex(u1, v1).lightmap(southLMa, southLMb).endVertex();
+        }
+
+        if (model.shouldRender(state, Direction.WEST)) {
+            int westCombined = getWorld().getCombinedLight(pos.west(), 0);
+            int westLMa = westCombined >> 16 & 65535;
+            int westLMb = westCombined & 65535;
+
+            bufferPos(buffer, bounds.getBackBottomLeft()).color(red, green, blue, alpha).tex(u1, v2).lightmap(westLMa, westLMb).endVertex();
+            bufferPos(buffer, bounds.getBackTopLeft()).color(red, green, blue, alpha).tex(u2, v2).lightmap(westLMa, westLMb).endVertex();
+            bufferPos(buffer, bounds.getFrontTopLeft()).color(red, green, blue, alpha).tex(u2, v1).lightmap(westLMa, westLMb).endVertex();
+            bufferPos(buffer, bounds.getFrontBottomLeft()).color(red, green, blue, alpha).tex(u1, v1).lightmap(westLMa, westLMb).endVertex();
+        }
+
+        if (model.shouldRender(state, Direction.EAST)) {
+            int eastCombined = getWorld().getCombinedLight(pos.east(), 0);
+            int eastLMa = eastCombined >> 16 & 65535;
+            int eastLMb = eastCombined & 65535;
+
+            bufferPos(buffer, bounds.getFrontBottomRight()).color(red, green, blue, alpha).tex(u1, v1).lightmap(eastLMa, eastLMb).endVertex();
+            bufferPos(buffer, bounds.getFrontTopRight()).color(red, green, blue, alpha).tex(u2, v1).lightmap(eastLMa, eastLMb).endVertex();
+            bufferPos(buffer, bounds.getBackTopRight()).color(red, green, blue, alpha).tex(u2, v2).lightmap(eastLMa, eastLMb).endVertex();
+            bufferPos(buffer, bounds.getBackBottomRight()).color(red, green, blue, alpha).tex(u1, v2).lightmap(eastLMa, eastLMb).endVertex();
+        }
+    }
+
+    /**
+     * Bind a {@link PlaceableItemsBlock} to a {@link FluidModel} implementation.
+     *
+     * @param block the block for which to bind the model
+     * @param model the model to bind
+     *
+     * @return this instance. Allows for chained method calls
+     */
+    public FluidHolderRenderer bind(PlaceableItemsBlock block, FluidModel model) {
+        this.fluidModels.put(block, model);
+        return this;
+    }
+
+    /**
+     * Clear all binded fluid models from this renderer. Ill-advised for modders to invoke this method.
+     * Unexpected issues may arise including the client crashing due to missing models.
+     */
+    public void clearFluidModels() {
+        this.fluidModels.clear();
+    }
+
+    private FluidHolderBlockComponent getFluidHolderBlockComponent(PlaceableItemsBlock block) {
+        for (IBlockComponent component : block.getComponents()) {
+            if (component instanceof FluidHolderBlockComponent) {
+                return (FluidHolderBlockComponent) component;
+            }
+        }
+
+        return null;
+    }
+
+    // Convenience method to buffer a Vector3d. It would be much uglier otherwise
+    private BufferBuilder bufferPos(BufferBuilder buffer, Vector3d pos) {
+        return buffer.pos(pos.x, pos.y, pos.z);
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
@@ -158,14 +158,6 @@ public class FluidHolderRenderer extends TileEntityRendererFast<FluidHolderTileE
         return this;
     }
 
-    /**
-     * Clear all binded fluid models from this renderer. Ill-advised for modders to invoke this method.
-     * Unexpected issues may arise including the client crashing due to missing models.
-     */
-    public void clearFluidModels() {
-        this.fluidModels.clear();
-    }
-
     private FluidHolderBlockComponent getFluidHolderBlockComponent(PlaceableItemsBlock block) {
         for (IBlockComponent component : block.getComponents()) {
             if (component instanceof FluidHolderBlockComponent) {

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
@@ -78,11 +78,14 @@ public class FluidHolderRenderer extends TileEntityRendererFast<FluidHolderTileE
         BlockPos pos = tile.getPos();
         AllVertexBoundingBox bounds = model.getRenderBounds(state);
 
+        // Conditionally cull and render specific directions
         if (model.shouldRender(state, Direction.DOWN)) {
+            // Fetch the value of the lights that strike this quad
             int downCombined = getWorld().getCombinedLight(pos.down(), 0);
             int downLMa = downCombined >> 16 & 65535;
             int downLMb = downCombined & 65535;
 
+            // Buffer quad positions, colours, texture coordinates (animated UV mappings) and light map coordinates. ORDER MATTERS HERE!
             bufferPos(buffer, bounds.getBackBottomLeft()).color(red, green, blue, alpha).tex(u1, v2).lightmap(downLMa, downLMb).endVertex();
             bufferPos(buffer, bounds.getFrontBottomLeft()).color(red, green, blue, alpha).tex(u1, v1).lightmap(downLMa, downLMb).endVertex();
             bufferPos(buffer, bounds.getFrontBottomRight()).color(red, green, blue, alpha).tex(u2, v1).lightmap(downLMa, downLMb).endVertex();

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
@@ -109,9 +109,9 @@ public class FluidHolderRenderer extends TileEntityRendererFast<FluidHolderTileE
             int northLMb = northCombined & 65535;
 
             bufferPos(buffer, bounds.getFrontBottomLeft()).color(red, green, blue, alpha).tex(u1, v1).lightmap(northLMa, northLMb).endVertex();
-            bufferPos(buffer, bounds.getFrontTopLeft()).color(red, green, blue, alpha).tex(u1, v2).lightmap(northLMa, northLMb).endVertex();
+            bufferPos(buffer, bounds.getFrontTopLeft()).color(red, green, blue, alpha).tex(u2, v1).lightmap(northLMa, northLMb).endVertex();
             bufferPos(buffer, bounds.getFrontTopRight()).color(red, green, blue, alpha).tex(u2, v2).lightmap(northLMa, northLMb).endVertex();
-            bufferPos(buffer, bounds.getFrontBottomRight()).color(red, green, blue, alpha).tex(u2, v1).lightmap(northLMa, northLMb).endVertex();
+            bufferPos(buffer, bounds.getFrontBottomRight()).color(red, green, blue, alpha).tex(u1, v2).lightmap(northLMa, northLMb).endVertex();
         }
 
         if (model.shouldRender(state, Direction.SOUTH)) {
@@ -119,9 +119,9 @@ public class FluidHolderRenderer extends TileEntityRendererFast<FluidHolderTileE
             int southLMa = southCombined >> 16 & 65535;
             int southLMb = southCombined & 65535;
 
-            bufferPos(buffer, bounds.getBackBottomRight()).color(red, green, blue, alpha).tex(u2, v1).lightmap(southLMa, southLMb).endVertex();
+            bufferPos(buffer, bounds.getBackBottomRight()).color(red, green, blue, alpha).tex(u1, v2).lightmap(southLMa, southLMb).endVertex();
             bufferPos(buffer, bounds.getBackTopRight()).color(red, green, blue, alpha).tex(u2, v2).lightmap(southLMa, southLMb).endVertex();
-            bufferPos(buffer, bounds.getBackTopLeft()).color(red, green, blue, alpha).tex(u1, v2).lightmap(southLMa, southLMb).endVertex();
+            bufferPos(buffer, bounds.getBackTopLeft()).color(red, green, blue, alpha).tex(u2, v1).lightmap(southLMa, southLMb).endVertex();
             bufferPos(buffer, bounds.getBackBottomLeft()).color(red, green, blue, alpha).tex(u1, v1).lightmap(southLMa, southLMb).endVertex();
         }
 

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
@@ -60,7 +60,7 @@ public class FluidHolderRenderer extends TileEntityRendererFast<FluidHolderTileE
         FluidModel model = this.fluidModels.get(block);
         Preconditions.checkState(model != null, "Missing model binding for FluidHolderTileEntity (" + tile.getClass().getName() + ")");
 
-        Vector3d rotationPoint = model.getRotationPoint(state);
+        Vector3d rotationPoint = model.getOrigin(state);
         buffer.setTranslation(x + (rotationPoint.x / 16F), y + (rotationPoint.y / 16F), z + (rotationPoint.z / 16F));
 
         // Render the fluid

--- a/Forge/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsBlockRegistry.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsBlockRegistry.java
@@ -4,13 +4,17 @@ import me.ferdz.placeableitems.PlaceableItems;
 import me.ferdz.placeableitems.block.PlaceableItemsBlock;
 import me.ferdz.placeableitems.block.PlaceableItemsBlockBuilder;
 import me.ferdz.placeableitems.block.component.impl.*;
+import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
 import me.ferdz.placeableitems.tileentity.StackHolderTileEntity;
 import me.ferdz.placeableitems.utils.VoxelShapesUtil;
 import me.ferdz.placeableitems.wiki.WikiDefinition;
 import net.minecraft.block.Block;
 import net.minecraft.item.Items;
+import net.minecraft.tags.FluidTags;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.math.shapes.VoxelShapes;
+
+import net.minecraftforge.common.Tags;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -396,6 +400,7 @@ public class PlaceableItemsBlockRegistry {
                 .register("firework_block", Items.FIREWORK_ROCKET);
         GLASS_BOTTLE = new PlaceableItemsBlockBuilder()
                 .addComponent(new BiPositionBlockComponent())
+                .addComponent(new FluidHolderBlockComponent(1000))
                 .build()
                 .setShape(VoxelShapesUtil.create(10, 12, 10))
                 .register("glass_bottle_block", Items.GLASS_BOTTLE);
@@ -567,6 +572,9 @@ public class PlaceableItemsBlockRegistry {
                 .create(StackHolderTileEntity::new, WRITABLE_BOOK)
                 .build(null)
                 .setRegistryName(PlaceableItems.MODID, "writable_book_block");
-        e.getRegistry().register(WRITABLE_BOOK_TILE_ENTITY);
+        e.getRegistry().registerAll(
+                WRITABLE_BOOK_TILE_ENTITY,
+                TileEntityType.Builder.create(FluidHolderTileEntity::new, GLASS_BOTTLE).build(null).setRegistryName(PlaceableItems.MODID, "fluid_holder")
+        );
     }
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/PlaceableItemsPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/PlaceableItemsPacketHandler.java
@@ -1,0 +1,31 @@
+package me.ferdz.placeableitems.network;
+
+import me.ferdz.placeableitems.PlaceableItems;
+
+import net.minecraft.util.ResourceLocation;
+
+import net.minecraftforge.fml.network.NetworkRegistry;
+import net.minecraftforge.fml.network.simple.SimpleChannel;
+
+/**
+ * A packet handler for the PlaceableItems mod.
+ *
+ * @author Parker Hawke - Choco
+ */
+public final class PlaceableItemsPacketHandler {
+
+    public static final String PROTOCOL_VERSION = "1";
+    public static final SimpleChannel INSTANCE = NetworkRegistry.newSimpleChannel(new ResourceLocation(PlaceableItems.MODID), () -> PROTOCOL_VERSION, PROTOCOL_VERSION::equals, PROTOCOL_VERSION::equals);
+
+    private static int id = 0;
+
+    private PlaceableItemsPacketHandler() { }
+
+    /**
+     * Initialize the packet handler.
+     */
+    public static void init() {
+        INSTANCE.registerMessage(id++, SUpdateFluidHolderPacket.class, SUpdateFluidHolderPacket::encode, SUpdateFluidHolderPacket::new, SUpdateFluidHolderPacket::handle);
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/PlaceableItemsPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/PlaceableItemsPacketHandler.java
@@ -1,9 +1,13 @@
 package me.ferdz.placeableitems.network;
 
 import me.ferdz.placeableitems.PlaceableItems;
+import me.ferdz.placeableitems.client.network.ClientPacketHandler;
+import me.ferdz.placeableitems.network.handler.AnonymousPacketHandler;
+import me.ferdz.placeableitems.network.handler.ServerPacketHandler;
 
 import net.minecraft.util.ResourceLocation;
 
+import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.network.NetworkRegistry;
 import net.minecraftforge.fml.network.simple.SimpleChannel;
 
@@ -17,6 +21,8 @@ public final class PlaceableItemsPacketHandler {
     public static final String PROTOCOL_VERSION = "1";
     public static final SimpleChannel INSTANCE = NetworkRegistry.newSimpleChannel(new ResourceLocation(PlaceableItems.MODID), () -> PROTOCOL_VERSION, PROTOCOL_VERSION::equals, PROTOCOL_VERSION::equals);
 
+    private static AnonymousPacketHandler handler;
+
     private static int id = 0;
 
     private PlaceableItemsPacketHandler() { }
@@ -25,7 +31,9 @@ public final class PlaceableItemsPacketHandler {
      * Initialize the packet handler.
      */
     public static void init() {
-        INSTANCE.registerMessage(id++, SUpdateFluidHolderPacket.class, SUpdateFluidHolderPacket::encode, SUpdateFluidHolderPacket::new, SUpdateFluidHolderPacket::handle);
+        handler = DistExecutor.runForDist(() -> () -> ClientPacketHandler.get(), () -> () -> ServerPacketHandler.get());
+
+        INSTANCE.registerMessage(id++, SUpdateFluidHolderPacket.class, SUpdateFluidHolderPacket::encode, SUpdateFluidHolderPacket::new, handler::handleUpdateFluidHolder);
     }
 
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/PlaceableItemsPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/PlaceableItemsPacketHandler.java
@@ -31,7 +31,7 @@ public final class PlaceableItemsPacketHandler {
      * Initialize the packet handler.
      */
     public static void init() {
-        handler = DistExecutor.runForDist(() -> () -> ClientPacketHandler.get(), () -> () -> ServerPacketHandler.get());
+        handler = DistExecutor.runForDist(() -> ClientPacketHandler::get, () -> ServerPacketHandler::get);
 
         INSTANCE.registerMessage(id++, SUpdateFluidHolderPacket.class, SUpdateFluidHolderPacket::encode, SUpdateFluidHolderPacket::new, handler::handleUpdateFluidHolder);
     }

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/SUpdateFluidHolderPacket.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/SUpdateFluidHolderPacket.java
@@ -1,20 +1,12 @@
 package me.ferdz.placeableitems.network;
 
-import java.util.function.Supplier;
-
 import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.PacketBuffer;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
-import net.minecraft.world.World;
 
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fml.network.NetworkDirection;
-import net.minecraftforge.fml.network.NetworkEvent;
 import net.minecraftforge.registries.ForgeRegistries;
 
 /**
@@ -84,34 +76,6 @@ public class SUpdateFluidHolderPacket {
         buffer.writeBlockPos(tilePos);
         buffer.writeString(fluidStack.getFluid().getRegistryName().toString());
         buffer.writeInt(fluidStack.getAmount());
-    }
-
-    /**
-     * Handle the receiving of this packet.
-     *
-     * @param ctx the network context
-     */
-    public void handle(Supplier<NetworkEvent.Context> ctx) {
-        NetworkEvent.Context context = ctx.get();
-        if (context.getDirection() != NetworkDirection.PLAY_TO_CLIENT) {
-            return;
-        }
-
-        context.enqueueWork(() -> {
-            World world = Minecraft.getInstance().world;
-            if (!world.getChunkProvider().isChunkLoaded(new ChunkPos(tilePos))) {
-                return;
-            }
-
-            TileEntity tile = world.getTileEntity(tilePos);
-            if (!(tile instanceof FluidHolderTileEntity)) {
-                return;
-            }
-
-            ((FluidHolderTileEntity) tile).setFluid(fluidStack);
-        });
-
-        context.setPacketHandled(true);
     }
 
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/SUpdateFluidHolderPacket.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/SUpdateFluidHolderPacket.java
@@ -1,0 +1,117 @@
+package me.ferdz.placeableitems.network;
+
+import java.util.function.Supplier;
+
+import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.network.NetworkDirection;
+import net.minecraftforge.fml.network.NetworkEvent;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/**
+ * A server -> client packet to update the state of a {@link FluidHolderTileEntity}.
+ *
+ * @author Parker Hawke - Choco
+ */
+public class SUpdateFluidHolderPacket {
+
+    private BlockPos tilePos;
+    private FluidStack fluidStack;
+
+    /**
+     * Create a new SUpdateFluidHolderPacket with the tile's position and fluid stack.
+     *
+     * @param tilePos the tile's position
+     * @param fluidStack the fluid stack
+     */
+    public SUpdateFluidHolderPacket(BlockPos tilePos, FluidStack fluidStack) {
+        this.tilePos = tilePos;
+        this.fluidStack = fluidStack;
+    }
+
+    /**
+     * Create a new SUpdateFluidHolderPacket based on the values supplied by the tile entity.
+     *
+     * @param tile the tile entity whose values may be used to populate this packet data
+     */
+    public SUpdateFluidHolderPacket(FluidHolderTileEntity tile) {
+        this(tile.getPos(), tile.getFluid());
+    }
+
+    /**
+     * Create a new SUpdateFluidHolderPacket from a PacketBuffer instance.
+     *
+     * @param buffer the packet buffer
+     */
+    public SUpdateFluidHolderPacket(PacketBuffer buffer) {
+        this.tilePos = buffer.readBlockPos();
+        this.fluidStack = new FluidStack(ForgeRegistries.FLUIDS.getValue(new ResourceLocation(buffer.readString())), buffer.readInt());
+    }
+
+    /**
+     * Get the tile's position.
+     *
+     * @return the tile position
+     */
+    public BlockPos getTilePos() {
+        return tilePos;
+    }
+
+    /**
+     * Get the fluid stack.
+     *
+     * @return the fluid stack
+     */
+    public FluidStack getFluidStack() {
+        return fluidStack;
+    }
+
+    /**
+     * Write this packet's data into the supplied packet buffer.
+     *
+     * @param buffer the buffer to which data should be written
+     */
+    public void encode(PacketBuffer buffer) {
+        buffer.writeBlockPos(tilePos);
+        buffer.writeString(fluidStack.getFluid().getRegistryName().toString());
+        buffer.writeInt(fluidStack.getAmount());
+    }
+
+    /**
+     * Handle the receiving of this packet.
+     *
+     * @param ctx the network context
+     */
+    public void handle(Supplier<NetworkEvent.Context> ctx) {
+        NetworkEvent.Context context = ctx.get();
+        if (context.getDirection() != NetworkDirection.PLAY_TO_CLIENT) {
+            return;
+        }
+
+        context.enqueueWork(() -> {
+            World world = Minecraft.getInstance().world;
+            if (!world.getChunkProvider().isChunkLoaded(new ChunkPos(tilePos))) {
+                return;
+            }
+
+            TileEntity tile = world.getTileEntity(tilePos);
+            if (!(tile instanceof FluidHolderTileEntity)) {
+                return;
+            }
+
+            ((FluidHolderTileEntity) tile).setFluid(fluidStack);
+        });
+
+        context.setPacketHandled(true);
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/SUpdateFluidHolderPacket.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/SUpdateFluidHolderPacket.java
@@ -33,10 +33,10 @@ public class SUpdateFluidHolderPacket {
     /**
      * Create a new SUpdateFluidHolderPacket based on the values supplied by the tile entity.
      *
-     * @param tile the tile entity whose values may be used to populate this packet data
+     * @param tileEntity the tile entity whose values may be used to populate this packet data
      */
-    public SUpdateFluidHolderPacket(FluidHolderTileEntity tile) {
-        this(tile.getPos(), tile.getFluid());
+    public SUpdateFluidHolderPacket(FluidHolderTileEntity tileEntity) {
+        this(tileEntity.getPos(), tileEntity.getFluid());
     }
 
     /**

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/handler/AnonymousPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/handler/AnonymousPacketHandler.java
@@ -6,8 +6,19 @@ import me.ferdz.placeableitems.network.SUpdateFluidHolderPacket;
 
 import net.minecraftforge.fml.network.NetworkEvent;
 
+/**
+ * Represents an anonymous packet handler. 
+ *
+ * @author Parker Hawke - Choco
+ */
 public interface AnonymousPacketHandler {
 
+    /**
+     * Handle the {@link SUpdateFluidHolderPacket}.
+     *
+     * @param packet the packet to handle
+     * @param ctx the network context
+     */
     public void handleUpdateFluidHolder(SUpdateFluidHolderPacket packet, Supplier<NetworkEvent.Context> ctx);
 
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/handler/AnonymousPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/handler/AnonymousPacketHandler.java
@@ -1,0 +1,13 @@
+package me.ferdz.placeableitems.network.handler;
+
+import java.util.function.Supplier;
+
+import me.ferdz.placeableitems.network.SUpdateFluidHolderPacket;
+
+import net.minecraftforge.fml.network.NetworkEvent;
+
+public interface AnonymousPacketHandler {
+
+    public void handleUpdateFluidHolder(SUpdateFluidHolderPacket packet, Supplier<NetworkEvent.Context> ctx);
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/handler/ServerPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/handler/ServerPacketHandler.java
@@ -8,6 +8,11 @@ import net.minecraft.util.LazyLoadBase;
 
 import net.minecraftforge.fml.network.NetworkEvent;
 
+/**
+ * Server-sided implementation of {@link AnonymousPacketHandler}.
+ *
+ * @author Parker Hawke - Choco
+ */
 public final class ServerPacketHandler implements AnonymousPacketHandler {
 
     private static final LazyLoadBase<AnonymousPacketHandler> INSTANCE  = new LazyLoadBase<>(() -> new ServerPacketHandler());

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/handler/ServerPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/handler/ServerPacketHandler.java
@@ -1,0 +1,26 @@
+package me.ferdz.placeableitems.network.handler;
+
+import java.util.function.Supplier;
+
+import me.ferdz.placeableitems.network.SUpdateFluidHolderPacket;
+
+import net.minecraft.util.LazyLoadBase;
+
+import net.minecraftforge.fml.network.NetworkEvent;
+
+public final class ServerPacketHandler implements AnonymousPacketHandler {
+
+    private static final LazyLoadBase<AnonymousPacketHandler> INSTANCE  = new LazyLoadBase<>(() -> new ServerPacketHandler());
+
+    private ServerPacketHandler() { }
+
+    @Override
+    public void handleUpdateFluidHolder(SUpdateFluidHolderPacket packet, Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().setPacketHandled(true);
+    }
+
+    public static AnonymousPacketHandler get() {
+        return INSTANCE.getValue();
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/tileentity/FluidHolderTileEntity.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/tileentity/FluidHolderTileEntity.java
@@ -1,0 +1,133 @@
+package me.ferdz.placeableitems.tileentity;
+
+import me.ferdz.placeableitems.PlaceableItems;
+
+import net.minecraft.fluid.Fluid;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityType;
+
+import net.minecraftforge.common.util.Constants;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.registries.ObjectHolder;
+
+/**
+ * Represents a tile entity capable of holding a {@link FluidStack}.
+ *
+ * @author Parker Hawke - Choco
+ */
+public class FluidHolderTileEntity extends TileEntity {
+
+    @ObjectHolder(PlaceableItems.MODID + ":fluid_holder")
+    public static final TileEntityType<FluidHolderTileEntity> TYPE = null;
+
+    private FluidStack fluid = FluidStack.EMPTY;
+
+    public FluidHolderTileEntity() {
+        super(TYPE);
+    }
+
+    /**
+     * Set the FluidStack held by this entity.
+     *
+     * @param fluid the fluid to set. If null, empty will be used.
+     */
+    public void setFluid(FluidStack fluid) {
+        this.fluid = (fluid != null) ? fluid : FluidStack.EMPTY;
+        this.markDirty();
+    }
+
+    /**
+     * Set the Fluid to be held by this entity. Amount will be maintained.
+     * Only the fluid's type is changed.
+     *
+     * @param fluid the fluid to set. If null, empty will be used
+     *
+     * @return true if successful, false otherwise
+     */
+    public boolean setFluid(Fluid fluid) {
+        if (fluid == null) {
+            if (this.fluid.isEmpty()) {
+                return false;
+            }
+
+            this.setFluid(FluidStack.EMPTY);
+            return true;
+        }
+
+        if (this.fluid.getFluid() != fluid) {
+            this.setFluid(new FluidStack(fluid, getFluidAmount()));
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the amount of fluid held by this tile entity. If no fluid, 0 will be returned.
+     *
+     * @return this tile's fluid amount
+     */
+    public int getFluidAmount() {
+        return fluid.getAmount();
+    }
+
+    /**
+     * Set the amount of fluid held by this tile entity. If no fluid, this method fails
+     * silently.
+     *
+     * @param amount the amount of fluid to set.
+     *
+     * @return true if changed, false if no fluid is held by this tile
+     */
+    public boolean setFluidAmount(int amount) {
+        if (fluid.isEmpty()) {
+            return false;
+        }
+
+        this.fluid.setAmount(amount);
+        this.markDirty();
+        return true;
+    }
+
+    /**
+     * Get a copy of the FluidStack held by this tile entity.
+     *
+     * @return the fluid stack
+     */
+    public FluidStack getFluid() {
+        return fluid.copy();
+    }
+
+    @Override
+    public CompoundNBT write(CompoundNBT compound) {
+        super.write(compound);
+
+        if (fluid != FluidStack.EMPTY) {
+            compound.put("Fluid", fluid.writeToNBT(new CompoundNBT()));
+        }
+
+        return compound;
+    }
+
+    @Override
+    public void read(CompoundNBT compound) {
+        super.read(compound);
+
+        if (compound.contains("Fluid", Constants.NBT.TAG_COMPOUND)) {
+            this.fluid = FluidStack.loadFluidStackFromNBT(compound.getCompound("Fluid"));
+        }
+    }
+
+    @Override
+    public CompoundNBT getUpdateTag() {
+        return fluid.writeToNBT(super.getUpdateTag());
+    }
+
+    @Override
+    public void handleUpdateTag(CompoundNBT tag) {
+        super.handleUpdateTag(tag);
+        this.fluid = FluidStack.loadFluidStackFromNBT(tag);
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/tileentity/FluidHolderTileEntity.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/tileentity/FluidHolderTileEntity.java
@@ -33,7 +33,7 @@ public class FluidHolderTileEntity extends TileEntity {
      * @param fluid the fluid to set. If null, empty will be used.
      */
     public void setFluid(FluidStack fluid) {
-        this.fluid = (fluid != null) ? fluid : FluidStack.EMPTY;
+        this.fluid = (fluid != null) ? fluid.copy() : FluidStack.EMPTY;
         this.markDirty();
     }
 
@@ -42,52 +42,18 @@ public class FluidHolderTileEntity extends TileEntity {
      * Only the fluid's type is changed.
      *
      * @param fluid the fluid to set. If null, empty will be used
-     *
-     * @return true if successful, false otherwise
      */
-    public boolean setFluid(Fluid fluid) {
+    public void setFluid(Fluid fluid) {
         if (fluid == null) {
             if (this.fluid.isEmpty()) {
-                return false;
+                return;
             }
 
             this.setFluid(FluidStack.EMPTY);
-            return true;
         }
-
-        if (this.fluid.getFluid() != fluid) {
-            this.setFluid(new FluidStack(fluid, getFluidAmount()));
-            return true;
+        else if (this.fluid.getFluid() != fluid) {
+            this.setFluid(new FluidStack(fluid, this.fluid.getAmount()));
         }
-
-        return false;
-    }
-
-    /**
-     * Get the amount of fluid held by this tile entity. If no fluid, 0 will be returned.
-     *
-     * @return this tile's fluid amount
-     */
-    public int getFluidAmount() {
-        return fluid.getAmount();
-    }
-
-    /**
-     * Set the amount of fluid held by this tile entity. If no fluid, this method fails
-     * silently.
-     *
-     * @param amount the amount of fluid to set.
-     *
-     * @return true if changed, false if no fluid is held by this tile
-     */
-    public boolean setFluidAmount(int amount) {
-        if (fluid.isEmpty()) {
-            return false;
-        }
-
-        this.fluid.setAmount(amount);
-        this.markDirty();
-        return true;
     }
 
     /**


### PR DESCRIPTION
This PR aims to add a new block component, `FluidHolderBlockComponent` which allows blocks to contain fluids and be interacted with using a bucket. It supports all vanilla and modded fluids and is server-friendly. Everything in this PR has been documented but the general idea is as such:
- Add the `FluidHolderBlockComponent` with a maximum fluid amount (in millibuckets)
  - Optionally specify a Fluid predicate to whitelist fluids
  - Optionally specify whether the fluid should be rendered in the world (some fluid containers may not be transparent as the glass bottle and may not need rendering)
- If the fluid should render (true by default), a `FluidModel` must be bound to the `FluidModelRenderer` instance initialized in the `ClientListener`.
- Different blocks will likely have different fluid models, therefore an implementation of `FluidModel` must be made. See `GlassBottleFluidModel` for an example.
  - Models are cached based on unique states to prevent unnecessary recalculation of the models

This PR is still a WIP as it's only functional on Forge. I'm unfamiliar with Fabric but I can't imagine a port will be terribly difficult so long as I do some research. However, I am creating a pull request now with the fully functioning Forge implementation to get feedback on the design / compatibility. I'm unsure the conventions required by this mod so please request changes where necessary. I tried to stay in line with most project conventions unless 1.14 Forge APIs allowed for a cleaner way to execute things than is already present (TileEntityType for instance)

![Fluid bottles](https://i.imgur.com/0BknkAY.jpg)

**NOTE:** I've only bothered implementing glass bottles as fluid holders, although I'm certain there are more that could hold fluids (bowls namely). Though I will leave that decision up to the maintainers if this PR gets merged, more fluid holders and models can be created :)