### PR TITLE
Add a keybind to place items (implements and closes #13)

### DIFF
--- a/Fabric/src/main/java/me/ferdz/placeableitems/PlaceableItems.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/PlaceableItems.java
@@ -17,7 +17,7 @@ public class PlaceableItems implements ModInitializer, ClientModInitializer {
 
     public static final String MODID = "placeableitems";
 
-    public static final Identifier PACKET_ID_NOTIFY_SPECIAL_ITEM_PLACE_KEY = new Identifier(PlaceableItems.MODID, "notify_special_item_place_key");
+    public static final Identifier PACKET_ID_NOTIFY_ITEM_PLACE_KEY = new Identifier(PlaceableItems.MODID, "notify_item_place_key");
 
     // Directly reference a log4j logger.
     public static Logger logger = Logger.getLogger("placeableitems");
@@ -33,7 +33,7 @@ public class PlaceableItems implements ModInitializer, ClientModInitializer {
         PlaceableItemsItemsRegistry.onItemsRegistry();
         PlaceableItemBlockEntityRegistry.registerTE();
 
-        ServerSidePacketRegistry.INSTANCE.register(PACKET_ID_NOTIFY_SPECIAL_ITEM_PLACE_KEY, (context, data) -> {
+        ServerSidePacketRegistry.INSTANCE.register(PACKET_ID_NOTIFY_ITEM_PLACE_KEY, (context, data) -> {
             boolean pressed = data.readBoolean();
             context.getTaskQueue().execute(() -> {
                 PlaceableItems.setKeyPressed(pressed);

--- a/Fabric/src/main/java/me/ferdz/placeableitems/PlaceableItems.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/PlaceableItems.java
@@ -1,10 +1,15 @@
 package me.ferdz.placeableitems;
 
+import me.ferdz.placeableitems.client.PlaceableItemsClientHandler;
 import me.ferdz.placeableitems.init.PlaceableItemBlockEntityRegistry;
 import me.ferdz.placeableitems.init.PlaceableItemsBlockRegistry;
 import me.ferdz.placeableitems.init.PlaceableItemsItemsRegistry;
+
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
+
+import net.minecraft.util.Identifier;
 
 import java.util.logging.Logger;
 
@@ -12,8 +17,12 @@ public class PlaceableItems implements ModInitializer, ClientModInitializer {
 
     public static final String MODID = "placeableitems";
 
+    public static final Identifier PACKET_ID_NOTIFY_SPECIAL_ITEM_PLACE_KEY = new Identifier(PlaceableItems.MODID, "notify_special_item_place_key");
+
     // Directly reference a log4j logger.
     public static Logger logger = Logger.getLogger("placeableitems");
+
+    private static boolean keyPressed = false;
 
     public PlaceableItems() {
     }
@@ -23,10 +32,28 @@ public class PlaceableItems implements ModInitializer, ClientModInitializer {
         PlaceableItemsBlockRegistry.onBlocksRegistry();
         PlaceableItemsItemsRegistry.onItemsRegistry();
         PlaceableItemBlockEntityRegistry.registerTE();
+
+        ServerSidePacketRegistry.INSTANCE.register(PACKET_ID_NOTIFY_SPECIAL_ITEM_PLACE_KEY, (context, data) -> {
+            boolean pressed = data.readBoolean();
+            context.getTaskQueue().execute(() -> {
+                PlaceableItems.setKeyPressed(pressed);
+            });
+        });
     }
 
     @Override
     public void onInitializeClient() {
+        PlaceableItemsClientHandler.registerPackets();
+        PlaceableItemsClientHandler.registerKeybindings();
         PlaceableItemBlockEntityRegistry.registerTERenderer();
     }
+
+    public static void setKeyPressed(boolean keyPressed) {
+        PlaceableItems.keyPressed = keyPressed;
+    }
+
+    public static boolean isKeyPressed() {
+        return keyPressed;
+    }
+
 }

--- a/Fabric/src/main/java/me/ferdz/placeableitems/client/PlaceableItemsClientHandler.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/client/PlaceableItemsClientHandler.java
@@ -1,0 +1,50 @@
+package me.ferdz.placeableitems.client;
+
+import me.ferdz.placeableitems.PlaceableItems;
+
+import net.fabricmc.fabric.api.client.keybinding.FabricKeyBinding;
+import net.fabricmc.fabric.api.client.keybinding.KeyBindingRegistry;
+import net.fabricmc.fabric.api.event.client.ClientTickCallback;
+import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.util.InputUtil;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.PacketByteBuf;
+
+import org.lwjgl.glfw.GLFW;
+
+import io.netty.buffer.Unpooled;
+
+public class PlaceableItemsClientHandler {
+
+    private static final FabricKeyBinding KEY_BINDING_PLACE_SPECIAL_ITEM = FabricKeyBinding.Builder.create(
+            new Identifier(PlaceableItems.MODID, "place_special_item"),
+            InputUtil.Type.KEYSYM,
+            GLFW.GLFW_KEY_LEFT_SHIFT,
+            "key.categories." + PlaceableItems.MODID
+    ).build();
+
+    public static void registerPackets() {
+        ClientSidePacketRegistry.INSTANCE.register(PlaceableItems.PACKET_ID_NOTIFY_SPECIAL_ITEM_PLACE_KEY, (context, data) -> { /* server bound packet. this can be ignored */ });
+    }
+
+    public static void registerKeybindings() {
+        KeyBindingRegistry.INSTANCE.register(KEY_BINDING_PLACE_SPECIAL_ITEM);
+
+        ClientTickCallback.EVENT.register(e -> {
+            // For whatever reason, FabricKeyBinding.isPressed() does NOT work for conflicting keybinds, despite having the same code...
+            // So we fall back to polling directly from GLFW's getKey() function.
+            boolean pressed = GLFW.glfwGetKey(MinecraftClient.getInstance().window.getHandle(), KEY_BINDING_PLACE_SPECIAL_ITEM.getBoundKey().getKeyCode()) == 1;
+
+            if (PlaceableItems.isKeyPressed() != pressed) {
+                PlaceableItems.setKeyPressed(pressed);
+
+                PacketByteBuf buffer = new PacketByteBuf(Unpooled.buffer());
+                buffer.writeBoolean(pressed);
+                ClientSidePacketRegistry.INSTANCE.sendToServer(PlaceableItems.PACKET_ID_NOTIFY_SPECIAL_ITEM_PLACE_KEY, buffer);
+            }
+        });
+    }
+
+}

--- a/Fabric/src/main/java/me/ferdz/placeableitems/client/PlaceableItemsClientHandler.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/client/PlaceableItemsClientHandler.java
@@ -18,31 +18,31 @@ import io.netty.buffer.Unpooled;
 
 public class PlaceableItemsClientHandler {
 
-    private static final FabricKeyBinding KEY_BINDING_PLACE_SPECIAL_ITEM = FabricKeyBinding.Builder.create(
-            new Identifier(PlaceableItems.MODID, "place_special_item"),
+    private static final FabricKeyBinding KEY_BINDING_PLACE_ITEM = FabricKeyBinding.Builder.create(
+            new Identifier(PlaceableItems.MODID, "place_item"),
             InputUtil.Type.KEYSYM,
             GLFW.GLFW_KEY_LEFT_SHIFT,
             "key.categories." + PlaceableItems.MODID
     ).build();
 
     public static void registerPackets() {
-        ClientSidePacketRegistry.INSTANCE.register(PlaceableItems.PACKET_ID_NOTIFY_SPECIAL_ITEM_PLACE_KEY, (context, data) -> { /* server bound packet. this can be ignored */ });
+        ClientSidePacketRegistry.INSTANCE.register(PlaceableItems.PACKET_ID_NOTIFY_ITEM_PLACE_KEY, (context, data) -> { /* server bound packet. this can be ignored */ });
     }
 
     public static void registerKeybindings() {
-        KeyBindingRegistry.INSTANCE.register(KEY_BINDING_PLACE_SPECIAL_ITEM);
+        KeyBindingRegistry.INSTANCE.register(KEY_BINDING_PLACE_ITEM);
 
         ClientTickCallback.EVENT.register(e -> {
             // For whatever reason, FabricKeyBinding.isPressed() does NOT work for conflicting keybinds, despite having the same code...
             // So we fall back to polling directly from GLFW's getKey() function.
-            boolean pressed = GLFW.glfwGetKey(MinecraftClient.getInstance().window.getHandle(), KEY_BINDING_PLACE_SPECIAL_ITEM.getBoundKey().getKeyCode()) == 1;
+            boolean pressed = GLFW.glfwGetKey(MinecraftClient.getInstance().window.getHandle(), KEY_BINDING_PLACE_ITEM.getBoundKey().getKeyCode()) == 1;
 
             if (PlaceableItems.isKeyPressed() != pressed) {
                 PlaceableItems.setKeyPressed(pressed);
 
                 PacketByteBuf buffer = new PacketByteBuf(Unpooled.buffer());
                 buffer.writeBoolean(pressed);
-                ClientSidePacketRegistry.INSTANCE.sendToServer(PlaceableItems.PACKET_ID_NOTIFY_SPECIAL_ITEM_PLACE_KEY, buffer);
+                ClientSidePacketRegistry.INSTANCE.sendToServer(PlaceableItems.PACKET_ID_NOTIFY_ITEM_PLACE_KEY, buffer);
             }
         });
     }

--- a/Fabric/src/main/java/me/ferdz/placeableitems/mixin/OnItemPlaceMxn.java
+++ b/Fabric/src/main/java/me/ferdz/placeableitems/mixin/OnItemPlaceMxn.java
@@ -1,5 +1,6 @@
 package me.ferdz.placeableitems.mixin;
 
+import me.ferdz.placeableitems.PlaceableItems;
 import me.ferdz.placeableitems.block.PlaceableItemsBlock;
 import me.ferdz.placeableitems.init.PlaceableItemsMap;
 import net.minecraft.item.*;
@@ -15,7 +16,7 @@ public abstract class OnItemPlaceMxn {
     @Inject(at = @At("HEAD"), method = "useOnBlock", cancellable = true)
     public void placeableItemInteractBlock(ItemUsageContext itemUsageContext, CallbackInfoReturnable<ActionResult> callback) {
         PlaceableItemsBlock block = PlaceableItemsMap.instance().get(itemUsageContext.getStack().getItem());
-        if (itemUsageContext.getPlayer().isSneaking() && block != null) {
+        if (PlaceableItems.isKeyPressed() && block != null) {
             BlockItem placeableBlockitem = new BlockItem(block, new Item.Settings());
             ActionResult result = placeableBlockitem.place(new ItemPlacementContext(itemUsageContext));
             callback.setReturnValue(result);

--- a/Fabric/src/main/resources/assets/placeableitems/lang/en_us.json
+++ b/Fabric/src/main/resources/assets/placeableitems/lang/en_us.json
@@ -2,5 +2,5 @@
     "block.placeableitems.saddle_stand_block": "Saddle Stand",
 
     "key.categories.placeableitems": "Placeable Items",
-    "key.placeableitems.place_item": "Place Item"
+    "key.placeableitems.place_item": "Place Item (Hold)"
 }

--- a/Fabric/src/main/resources/assets/placeableitems/lang/en_us.json
+++ b/Fabric/src/main/resources/assets/placeableitems/lang/en_us.json
@@ -2,5 +2,5 @@
     "block.placeableitems.saddle_stand_block": "Saddle Stand",
 
     "key.categories.placeableitems": "Placeable Items",
-    "key.placeableitems.place_special_item": "Place Special Item"
+    "key.placeableitems.place_item": "Place Item"
 }

--- a/Fabric/src/main/resources/assets/placeableitems/lang/en_us.json
+++ b/Fabric/src/main/resources/assets/placeableitems/lang/en_us.json
@@ -1,3 +1,6 @@
 {
-    "block.placeableitems.saddle_stand_block": "Saddle Stand"
+    "block.placeableitems.saddle_stand_block": "Saddle Stand",
+
+    "key.categories.placeableitems": "Placeable Items",
+    "key.placeableitems.place_special_item": "Place Special Item"
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/PlaceableItems.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/PlaceableItems.java
@@ -34,12 +34,7 @@ public final class PlaceableItems {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onCommonSetup);
         MinecraftForge.EVENT_BUS.register(this.placeHandler = new ItemPlaceHandler());
 
-        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
-            ClientListener clientListener = ClientListener.get();
-
-            FMLJavaModLoadingContext.get().getModEventBus().register(clientListener.getModBus());
-            MinecraftForge.EVENT_BUS.register(clientListener.getForgeBus());
-        });
+        DistExecutor.runWhenOn(Dist.CLIENT, () -> ClientListener::get);
 
         if(GENERATE_WIKI) {
             FMLJavaModLoadingContext.get().getModEventBus().addListener(this::generateWiki);

--- a/Forge/src/main/java/me/ferdz/placeableitems/PlaceableItems.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/PlaceableItems.java
@@ -15,19 +15,31 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 @Mod(PlaceableItems.MODID)
-public class PlaceableItems {
+public final class PlaceableItems {
 
     public static final String MODID = "placeableitems";
     private static final boolean GENERATE_WIKI = "true".equals(System.getenv().get("GENERATE_WIKI"));
 
     // Directly reference a log4j logger.
-    private static final Logger LOGGER = LogManager.getLogger();
+    public static final Logger LOGGER = LogManager.getLogger();
+
+    private static PlaceableItems instance;
+
+    private final ItemPlaceHandler placeHandler;
 
     public PlaceableItems() {
+        instance = this;
+
         // Register ourselves for server and other game events we are interested in
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onCommonSetup);
-        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> FMLJavaModLoadingContext.get().getModEventBus().register(ClientListener.get()));
-        MinecraftForge.EVENT_BUS.register(new ItemPlaceHandler());
+        MinecraftForge.EVENT_BUS.register(this.placeHandler = new ItemPlaceHandler());
+
+        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> {
+            ClientListener clientListener = ClientListener.get();
+
+            FMLJavaModLoadingContext.get().getModEventBus().register(clientListener.getModBus());
+            MinecraftForge.EVENT_BUS.register(clientListener.getForgeBus());
+        });
 
         if(GENERATE_WIKI) {
             FMLJavaModLoadingContext.get().getModEventBus().addListener(this::generateWiki);
@@ -42,4 +54,23 @@ public class PlaceableItems {
         WikiGenerator generator = new WikiGenerator();
         generator.generate();
     }
+
+    /**
+     * Get an instance of the {@link ItemPlaceHandler}.
+     *
+     * @return the item place handler
+     */
+    public ItemPlaceHandler getPlaceHandler() {
+        return placeHandler;
+    }
+
+    /**
+     * Get the singleton instance of this mod.
+     *
+     * @return this mod's instance
+     */
+    public static PlaceableItems getInstance() {
+        return instance;
+    }
+
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/ClientListener.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/ClientListener.java
@@ -5,7 +5,7 @@ import me.ferdz.placeableitems.client.model.GlassBottleFluidModel;
 import me.ferdz.placeableitems.client.renderer.tileentity.FluidHolderRenderer;
 import me.ferdz.placeableitems.event.ItemPlaceHandler;
 import me.ferdz.placeableitems.init.PlaceableItemsBlockRegistry;
-import me.ferdz.placeableitems.network.CNotifySpecialItemPlaceKeyPacket;
+import me.ferdz.placeableitems.network.CNotifyItemPlaceKeyPacket;
 import me.ferdz.placeableitems.network.PlaceableItemsPacketHandler;
 import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
 
@@ -51,7 +51,7 @@ public final class ClientListener {
             return;
         }
 
-        PlaceableItemsPacketHandler.INSTANCE.sendToServer(new CNotifySpecialItemPlaceKeyPacket(pressed));
+        PlaceableItemsPacketHandler.INSTANCE.sendToServer(new CNotifyItemPlaceKeyPacket(pressed));
         placeHandler.setHoldingKey(pressed);
     }
 

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/ClientListener.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/ClientListener.java
@@ -1,27 +1,79 @@
 package me.ferdz.placeableitems.client;
 
+import me.ferdz.placeableitems.PlaceableItems;
 import me.ferdz.placeableitems.client.model.GlassBottleFluidModel;
 import me.ferdz.placeableitems.client.renderer.tileentity.FluidHolderRenderer;
+import me.ferdz.placeableitems.event.ItemPlaceHandler;
 import me.ferdz.placeableitems.init.PlaceableItemsBlockRegistry;
+import me.ferdz.placeableitems.network.CNotifySpecialItemPlaceKeyPacket;
+import me.ferdz.placeableitems.network.PlaceableItemsPacketHandler;
 import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
 
+import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.util.LazyLoadBase;
 
+import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+
+import org.lwjgl.glfw.GLFW;
 
 public final class ClientListener {
 
     private static final LazyLoadBase<ClientListener> INSTANCE = new LazyLoadBase<>(ClientListener::new);
 
-    private ClientListener() { }
+    private static final KeyBinding KEY_BINDING_PLACE_SPECIAL_ITEM = new KeyBinding("key." + PlaceableItems.MODID + ".place_special_item", GLFW.GLFW_KEY_LEFT_SHIFT, "key.categories." + PlaceableItems.MODID);
 
-    @SubscribeEvent // Fluid models should be binded here:
-    void onClientSetup(@SuppressWarnings("unused") FMLClientSetupEvent event) {
-        ClientRegistry.bindTileEntitySpecialRenderer(FluidHolderTileEntity.class, new FluidHolderRenderer()
-                .bind(PlaceableItemsBlockRegistry.GLASS_BOTTLE, new GlassBottleFluidModel())
-        );
+    private final ModBus modBus;
+    private final ForgeBus forgeBus;
+
+    private ClientListener() {
+        this.modBus = new ModBus();
+        this.forgeBus = new ForgeBus();
+    }
+
+    public ModBus getModBus() {
+        return modBus;
+    }
+
+    public ForgeBus getForgeBus() {
+        return forgeBus;
+    }
+
+    public class ModBus {
+
+        @SubscribeEvent // Fluid models should be binded here:
+        void onClientSetup(@SuppressWarnings("unused") FMLClientSetupEvent event) {
+            ClientRegistry.bindTileEntitySpecialRenderer(FluidHolderTileEntity.class, new FluidHolderRenderer()
+                    .bind(PlaceableItemsBlockRegistry.GLASS_BOTTLE, new GlassBottleFluidModel())
+            );
+
+            ClientRegistry.registerKeyBinding(KEY_BINDING_PLACE_SPECIAL_ITEM);
+        }
+
+    }
+
+    public final class ForgeBus {
+
+        @SubscribeEvent
+        void onKeyPress(InputEvent.KeyInputEvent event) {
+            int action = event.getAction();
+            if (action == GLFW.GLFW_REPEAT || event.getKey() != KEY_BINDING_PLACE_SPECIAL_ITEM.getKey().getKeyCode()) {
+                return;
+            }
+
+            ItemPlaceHandler placeHandler = PlaceableItems.getInstance().getPlaceHandler();
+            boolean pressed = (action == GLFW.GLFW_PRESS);
+
+            if (placeHandler.isHoldingKey() == pressed) { // Don't send a packet if it hasn't changed states
+                return;
+            }
+
+            PlaceableItemsPacketHandler.INSTANCE.sendToServer(new CNotifySpecialItemPlaceKeyPacket(pressed));
+            placeHandler.setHoldingKey(pressed);
+        }
+
     }
 
     public static ClientListener get() {

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/ClientListener.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/ClientListener.java
@@ -13,9 +13,10 @@ import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.util.LazyLoadBase;
 
 import net.minecraftforge.client.event.InputEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 import org.lwjgl.glfw.GLFW;
 
@@ -23,61 +24,49 @@ public final class ClientListener {
 
     private static final LazyLoadBase<ClientListener> INSTANCE = new LazyLoadBase<>(ClientListener::new);
 
-    private static final KeyBinding KEY_BINDING_PLACE_SPECIAL_ITEM = new KeyBinding("key." + PlaceableItems.MODID + ".place_special_item", GLFW.GLFW_KEY_LEFT_SHIFT, "key.categories." + PlaceableItems.MODID);
+    private static final KeyBinding KEY_BINDING_PLACE_ITEM = new KeyBinding("key." + PlaceableItems.MODID + ".place_item", GLFW.GLFW_KEY_LEFT_SHIFT, "key.categories." + PlaceableItems.MODID);
 
-    private final ModBus modBus;
-    private final ForgeBus forgeBus;
+    private boolean registeredListeners = false;
 
-    private ClientListener() {
-        this.modBus = new ModBus();
-        this.forgeBus = new ForgeBus();
+    private ClientListener() { }
+
+    void onClientSetup(@SuppressWarnings("unused") FMLClientSetupEvent event) {
+        ClientRegistry.bindTileEntitySpecialRenderer(FluidHolderTileEntity.class, new FluidHolderRenderer()
+                .bind(PlaceableItemsBlockRegistry.GLASS_BOTTLE, new GlassBottleFluidModel())
+        );
+
+        ClientRegistry.registerKeyBinding(KEY_BINDING_PLACE_ITEM);
     }
 
-    public ModBus getModBus() {
-        return modBus;
-    }
-
-    public ForgeBus getForgeBus() {
-        return forgeBus;
-    }
-
-    public class ModBus {
-
-        @SubscribeEvent // Fluid models should be binded here:
-        void onClientSetup(@SuppressWarnings("unused") FMLClientSetupEvent event) {
-            ClientRegistry.bindTileEntitySpecialRenderer(FluidHolderTileEntity.class, new FluidHolderRenderer()
-                    .bind(PlaceableItemsBlockRegistry.GLASS_BOTTLE, new GlassBottleFluidModel())
-            );
-
-            ClientRegistry.registerKeyBinding(KEY_BINDING_PLACE_SPECIAL_ITEM);
+    void onKeyPress(InputEvent.KeyInputEvent event) {
+        int action = event.getAction();
+        if (action == GLFW.GLFW_REPEAT || event.getKey() != KEY_BINDING_PLACE_ITEM.getKey().getKeyCode()) {
+            return;
         }
 
-    }
+        ItemPlaceHandler placeHandler = PlaceableItems.getInstance().getPlaceHandler();
+        boolean pressed = (action == GLFW.GLFW_PRESS);
 
-    public final class ForgeBus {
-
-        @SubscribeEvent
-        void onKeyPress(InputEvent.KeyInputEvent event) {
-            int action = event.getAction();
-            if (action == GLFW.GLFW_REPEAT || event.getKey() != KEY_BINDING_PLACE_SPECIAL_ITEM.getKey().getKeyCode()) {
-                return;
-            }
-
-            ItemPlaceHandler placeHandler = PlaceableItems.getInstance().getPlaceHandler();
-            boolean pressed = (action == GLFW.GLFW_PRESS);
-
-            if (placeHandler.isHoldingKey() == pressed) { // Don't send a packet if it hasn't changed states
-                return;
-            }
-
-            PlaceableItemsPacketHandler.INSTANCE.sendToServer(new CNotifySpecialItemPlaceKeyPacket(pressed));
-            placeHandler.setHoldingKey(pressed);
+        if (placeHandler.isHoldingKey() == pressed) { // Don't send a packet if it hasn't changed states
+            return;
         }
 
+        PlaceableItemsPacketHandler.INSTANCE.sendToServer(new CNotifySpecialItemPlaceKeyPacket(pressed));
+        placeHandler.setHoldingKey(pressed);
     }
 
     public static ClientListener get() {
-        return INSTANCE.getValue();
+        ClientListener instance = INSTANCE.getValue();
+
+        // Register client-sided listeners here
+        if (!instance.registeredListeners) {
+            FMLJavaModLoadingContext.get().getModEventBus().addListener(instance::onClientSetup);
+            MinecraftForge.EVENT_BUS.addListener(instance::onKeyPress);
+
+            instance.registeredListeners = true;
+        }
+
+        return instance;
     }
 
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/network/ClientPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/network/ClientPacketHandler.java
@@ -2,7 +2,7 @@ package me.ferdz.placeableitems.client.network;
 
 import java.util.function.Supplier;
 
-import me.ferdz.placeableitems.network.CNotifySpecialItemPlaceKeyPacket;
+import me.ferdz.placeableitems.network.CNotifyItemPlaceKeyPacket;
 import me.ferdz.placeableitems.network.SUpdateFluidHolderPacket;
 import me.ferdz.placeableitems.network.handler.AnonymousPacketHandler;
 import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
@@ -48,7 +48,7 @@ public final class ClientPacketHandler implements AnonymousPacketHandler {
     }
 
     @Override
-    public void handleNotifySpecialItemPlaceKey(CNotifySpecialItemPlaceKeyPacket packet, Supplier<NetworkEvent.Context> ctx) {
+    public void handleNotifyItemPlaceKey(CNotifyItemPlaceKeyPacket packet, Supplier<NetworkEvent.Context> ctx) {
         ctx.get().setPacketHandled(true);
     }
 

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/network/ClientPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/network/ClientPacketHandler.java
@@ -2,6 +2,7 @@ package me.ferdz.placeableitems.client.network;
 
 import java.util.function.Supplier;
 
+import me.ferdz.placeableitems.network.CNotifySpecialItemPlaceKeyPacket;
 import me.ferdz.placeableitems.network.SUpdateFluidHolderPacket;
 import me.ferdz.placeableitems.network.handler.AnonymousPacketHandler;
 import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
@@ -44,6 +45,11 @@ public final class ClientPacketHandler implements AnonymousPacketHandler {
         });
 
         context.setPacketHandled(true);
+    }
+
+    @Override
+    public void handleNotifySpecialItemPlaceKey(CNotifySpecialItemPlaceKeyPacket packet, Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().setPacketHandled(true);
     }
 
     public static AnonymousPacketHandler get() {

--- a/Forge/src/main/java/me/ferdz/placeableitems/event/ItemPlaceHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/event/ItemPlaceHandler.java
@@ -2,25 +2,20 @@ package me.ferdz.placeableitems.event;
 
 import me.ferdz.placeableitems.block.PlaceableItemsBlock;
 import me.ferdz.placeableitems.init.PlaceableItemsMap;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.*;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.math.BlockRayTraceResult;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.RayTraceContext;
-import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class ItemPlaceHandler {
 
+    private boolean holdingKey = false;
+
     @SubscribeEvent
     public void onRightClickBlock(final PlayerInteractEvent.RightClickBlock e) {
-        if (!e.getPlayer().isSneaking()) { // TODO: #13 Make configurable hotkey for placing items
-            return; // Abort if the user is not sneaking
+        if (!holdingKey) { // Abort if the user is not holding the keybind
+            return;
         }
 
         ItemStack itemStack = e.getPlayer().getHeldItem(e.getHand());
@@ -44,4 +39,13 @@ public class ItemPlaceHandler {
             e.setCancellationResult(ActionResultType.SUCCESS);
         }
     }
+
+    public void setHoldingKey(boolean isHoldingKey) {
+        this.holdingKey = isHoldingKey;
+    }
+
+    public boolean isHoldingKey() {
+        return holdingKey;
+    }
+
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/CNotifyItemPlaceKeyPacket.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/CNotifyItemPlaceKeyPacket.java
@@ -8,7 +8,7 @@ import net.minecraft.network.PacketBuffer;
  *
  * @author Parker Hawke - Choco
  */
-public class CNotifySpecialItemPlaceKeyPacket {
+public class CNotifyItemPlaceKeyPacket {
 
     private boolean pressed;
 
@@ -17,7 +17,7 @@ public class CNotifySpecialItemPlaceKeyPacket {
      *
      * @param pressed whether or not it has been pressed
      */
-    public CNotifySpecialItemPlaceKeyPacket(boolean pressed) {
+    public CNotifyItemPlaceKeyPacket(boolean pressed) {
         this.pressed = pressed;
     }
 
@@ -26,7 +26,7 @@ public class CNotifySpecialItemPlaceKeyPacket {
      *
      * @param buffer the packet buffer
      */
-    public CNotifySpecialItemPlaceKeyPacket(PacketBuffer buffer) {
+    public CNotifyItemPlaceKeyPacket(PacketBuffer buffer) {
         this(buffer.readBoolean());
     }
 

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/CNotifySpecialItemPlaceKeyPacket.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/CNotifySpecialItemPlaceKeyPacket.java
@@ -1,0 +1,51 @@
+package me.ferdz.placeableitems.network;
+
+import net.minecraft.network.PacketBuffer;
+
+/**
+ * A client -> server packet to inform it of a client-sided keybind update for the
+ * special item place key.
+ *
+ * @author Parker Hawke - Choco
+ */
+public class CNotifySpecialItemPlaceKeyPacket {
+
+    private boolean pressed;
+
+    /**
+     * Create a new CNotifySpecialItemPlaceKeyPacket with the new key pressed state.
+     *
+     * @param pressed whether or not it has been pressed
+     */
+    public CNotifySpecialItemPlaceKeyPacket(boolean pressed) {
+        this.pressed = pressed;
+    }
+
+    /**
+     * Create a new CNotifySpecialItemPlaceKeyPacket from a PacketBuffer instance.
+     *
+     * @param buffer the packet buffer
+     */
+    public CNotifySpecialItemPlaceKeyPacket(PacketBuffer buffer) {
+        this(buffer.readBoolean());
+    }
+
+    /**
+     * Check whether or not the key should be declared as pressed.
+     *
+     * @return the new pressed state
+     */
+    public boolean isPressed() {
+        return pressed;
+    }
+
+    /**
+     * Write this packet's data into the supplied packet buffer.
+     *
+     * @param buffer the buffer to which data should be written
+     */
+    public void encode(PacketBuffer buffer) {
+        buffer.writeBoolean(pressed);
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/PlaceableItemsPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/PlaceableItemsPacketHandler.java
@@ -33,6 +33,10 @@ public final class PlaceableItemsPacketHandler {
     public static void init() {
         handler = DistExecutor.runForDist(() -> ClientPacketHandler::get, () -> ServerPacketHandler::get);
 
+        // Client packets
+        INSTANCE.registerMessage(id++, CNotifySpecialItemPlaceKeyPacket.class, CNotifySpecialItemPlaceKeyPacket::encode, CNotifySpecialItemPlaceKeyPacket::new, handler::handleNotifySpecialItemPlaceKey);
+
+        // Server packets
         INSTANCE.registerMessage(id++, SUpdateFluidHolderPacket.class, SUpdateFluidHolderPacket::encode, SUpdateFluidHolderPacket::new, handler::handleUpdateFluidHolder);
     }
 

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/PlaceableItemsPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/PlaceableItemsPacketHandler.java
@@ -34,7 +34,7 @@ public final class PlaceableItemsPacketHandler {
         handler = DistExecutor.runForDist(() -> ClientPacketHandler::get, () -> ServerPacketHandler::get);
 
         // Client packets
-        INSTANCE.registerMessage(id++, CNotifySpecialItemPlaceKeyPacket.class, CNotifySpecialItemPlaceKeyPacket::encode, CNotifySpecialItemPlaceKeyPacket::new, handler::handleNotifySpecialItemPlaceKey);
+        INSTANCE.registerMessage(id++, CNotifyItemPlaceKeyPacket.class, CNotifyItemPlaceKeyPacket::encode, CNotifyItemPlaceKeyPacket::new, handler::handleNotifyItemPlaceKey);
 
         // Server packets
         INSTANCE.registerMessage(id++, SUpdateFluidHolderPacket.class, SUpdateFluidHolderPacket::encode, SUpdateFluidHolderPacket::new, handler::handleUpdateFluidHolder);

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/handler/AnonymousPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/handler/AnonymousPacketHandler.java
@@ -2,7 +2,7 @@ package me.ferdz.placeableitems.network.handler;
 
 import java.util.function.Supplier;
 
-import me.ferdz.placeableitems.network.CNotifySpecialItemPlaceKeyPacket;
+import me.ferdz.placeableitems.network.CNotifyItemPlaceKeyPacket;
 import me.ferdz.placeableitems.network.SUpdateFluidHolderPacket;
 
 import net.minecraftforge.fml.network.NetworkEvent;
@@ -23,11 +23,11 @@ public interface AnonymousPacketHandler {
     public void handleUpdateFluidHolder(SUpdateFluidHolderPacket packet, Supplier<NetworkEvent.Context> ctx);
 
     /**
-     * Handle the {@link CNotifySpecialItemPlaceKeyPacket}.
+     * Handle the {@link CNotifyItemPlaceKeyPacket}.
      *
      * @param packet the packet to handle
      * @param ctx the network context
      */
-    public void handleNotifySpecialItemPlaceKey(CNotifySpecialItemPlaceKeyPacket packet, Supplier<NetworkEvent.Context> ctx);
+    public void handleNotifyItemPlaceKey(CNotifyItemPlaceKeyPacket packet, Supplier<NetworkEvent.Context> ctx);
 
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/handler/AnonymousPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/handler/AnonymousPacketHandler.java
@@ -2,6 +2,7 @@ package me.ferdz.placeableitems.network.handler;
 
 import java.util.function.Supplier;
 
+import me.ferdz.placeableitems.network.CNotifySpecialItemPlaceKeyPacket;
 import me.ferdz.placeableitems.network.SUpdateFluidHolderPacket;
 
 import net.minecraftforge.fml.network.NetworkEvent;
@@ -20,5 +21,13 @@ public interface AnonymousPacketHandler {
      * @param ctx the network context
      */
     public void handleUpdateFluidHolder(SUpdateFluidHolderPacket packet, Supplier<NetworkEvent.Context> ctx);
+
+    /**
+     * Handle the {@link CNotifySpecialItemPlaceKeyPacket}.
+     *
+     * @param packet the packet to handle
+     * @param ctx the network context
+     */
+    public void handleNotifySpecialItemPlaceKey(CNotifySpecialItemPlaceKeyPacket packet, Supplier<NetworkEvent.Context> ctx);
 
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/handler/ServerPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/handler/ServerPacketHandler.java
@@ -2,6 +2,8 @@ package me.ferdz.placeableitems.network.handler;
 
 import java.util.function.Supplier;
 
+import me.ferdz.placeableitems.PlaceableItems;
+import me.ferdz.placeableitems.network.CNotifySpecialItemPlaceKeyPacket;
 import me.ferdz.placeableitems.network.SUpdateFluidHolderPacket;
 
 import net.minecraft.util.LazyLoadBase;
@@ -22,6 +24,13 @@ public final class ServerPacketHandler implements AnonymousPacketHandler {
     @Override
     public void handleUpdateFluidHolder(SUpdateFluidHolderPacket packet, Supplier<NetworkEvent.Context> ctx) {
         ctx.get().setPacketHandled(true);
+    }
+
+    @Override
+    public void handleNotifySpecialItemPlaceKey(CNotifySpecialItemPlaceKeyPacket packet, Supplier<NetworkEvent.Context> ctx) {
+        NetworkEvent.Context context = ctx.get();
+        context.enqueueWork(() -> PlaceableItems.getInstance().getPlaceHandler().setHoldingKey(packet.isPressed()));
+        context.setPacketHandled(true);
     }
 
     public static AnonymousPacketHandler get() {

--- a/Forge/src/main/java/me/ferdz/placeableitems/network/handler/ServerPacketHandler.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/network/handler/ServerPacketHandler.java
@@ -3,7 +3,7 @@ package me.ferdz.placeableitems.network.handler;
 import java.util.function.Supplier;
 
 import me.ferdz.placeableitems.PlaceableItems;
-import me.ferdz.placeableitems.network.CNotifySpecialItemPlaceKeyPacket;
+import me.ferdz.placeableitems.network.CNotifyItemPlaceKeyPacket;
 import me.ferdz.placeableitems.network.SUpdateFluidHolderPacket;
 
 import net.minecraft.util.LazyLoadBase;
@@ -27,7 +27,7 @@ public final class ServerPacketHandler implements AnonymousPacketHandler {
     }
 
     @Override
-    public void handleNotifySpecialItemPlaceKey(CNotifySpecialItemPlaceKeyPacket packet, Supplier<NetworkEvent.Context> ctx) {
+    public void handleNotifyItemPlaceKey(CNotifyItemPlaceKeyPacket packet, Supplier<NetworkEvent.Context> ctx) {
         NetworkEvent.Context context = ctx.get();
         context.enqueueWork(() -> PlaceableItems.getInstance().getPlaceHandler().setHoldingKey(packet.isPressed()));
         context.setPacketHandled(true);

--- a/Forge/src/main/resources/META-INF/mods.toml
+++ b/Forge/src/main/resources/META-INF/mods.toml
@@ -24,7 +24,7 @@ displayURL="https://minecraft.curseforge.com/projects/placeable-items" #optional
 # A file name (in the root of the mod JAR) containing a logo for display
 logoFile="logo.png" #optional
 # A text field displayed in the mod UI
-credits="Big thanks to jbrion1995, jmeyer2k, emx2000 and McHorse for code contributions!" #optional
+credits="Big thanks to jbrion1995, jmeyer2k, emx2000, McHorse and Choco for code contributions!" #optional
 # A text field displayed in the mod UI
 authors="Ferdz (Author), MasterianoX (Models)" #optional
 # The description text for the mod (multi line!) (#mandatory)

--- a/Forge/src/main/resources/assets/placeableitems/lang/en_us.json
+++ b/Forge/src/main/resources/assets/placeableitems/lang/en_us.json
@@ -2,5 +2,5 @@
     "block.placeableitems.saddle_stand_block": "Saddle Stand",
 
     "key.categories.placeableitems": "Placeable Items",
-    "key.placeableitems.place_item": "Place Item"
+    "key.placeableitems.place_item": "Place Item (Hold)"
 }

--- a/Forge/src/main/resources/assets/placeableitems/lang/en_us.json
+++ b/Forge/src/main/resources/assets/placeableitems/lang/en_us.json
@@ -2,5 +2,5 @@
     "block.placeableitems.saddle_stand_block": "Saddle Stand",
 
     "key.categories.placeableitems": "Placeable Items",
-    "key.placeableitems.place_special_item": "Place Special Item"
+    "key.placeableitems.place_item": "Place Item"
 }

--- a/Forge/src/main/resources/assets/placeableitems/lang/en_us.json
+++ b/Forge/src/main/resources/assets/placeableitems/lang/en_us.json
@@ -1,3 +1,6 @@
 {
-    "block.placeableitems.saddle_stand_block": "Saddle Stand"
+    "block.placeableitems.saddle_stand_block": "Saddle Stand",
+
+    "key.categories.placeableitems": "Placeable Items",
+    "key.placeableitems.place_special_item": "Place Special Item"
 }


### PR DESCRIPTION
This PR aims to add a configurable keybind to place items for both Forge and Fabric and resolve a longstanding issue/request, #13. Because Fabric's packet system isn't as refined as that of Forge's, it's slightly sloppy, but it gets the job done.

The keybind has its own category and its own language entries, therefore only the en_US.json language files have been updated because I'm not confident enough in my French and am unfamiliar with the other available languages. This is something that will need to be addressed in the future.

![keybinding](https://i.imgur.com/OMyPX99.png)

By default, left shift is used as the keybinding but may be changed to any other key (as seen above). Left shift is used as the default to remain familiar to existing players while still giving the option of changing it if desired.