### PR TITLE
Improve the FluidModel rendering system. Supports multiple elements

### DIFF
--- a/Forge/src/main/java/me/ferdz/placeableitems/client/ClientListener.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/ClientListener.java
@@ -1,6 +1,7 @@
 package me.ferdz.placeableitems.client;
 
 import me.ferdz.placeableitems.PlaceableItems;
+import me.ferdz.placeableitems.client.model.FluidModel;
 import me.ferdz.placeableitems.client.model.GlassBottleFluidModel;
 import me.ferdz.placeableitems.client.renderer.tileentity.FluidHolderRenderer;
 import me.ferdz.placeableitems.event.ItemPlaceHandler;
@@ -27,11 +28,14 @@ public final class ClientListener {
     private static final KeyBinding KEY_BINDING_PLACE_ITEM = new KeyBinding("key." + PlaceableItems.MODID + ".place_item", GLFW.GLFW_KEY_LEFT_SHIFT, "key.categories." + PlaceableItems.MODID);
 
     private boolean registeredListeners = false;
+    private FluidHolderRenderer fluidHolderRenderer;
 
-    private ClientListener() { }
+    private ClientListener() {
+        this.fluidHolderRenderer = new FluidHolderRenderer();
+    }
 
     void onClientSetup(@SuppressWarnings("unused") FMLClientSetupEvent event) {
-        ClientRegistry.bindTileEntitySpecialRenderer(FluidHolderTileEntity.class, new FluidHolderRenderer()
+        ClientRegistry.bindTileEntitySpecialRenderer(FluidHolderTileEntity.class, fluidHolderRenderer
                 .bind(PlaceableItemsBlockRegistry.GLASS_BOTTLE, new GlassBottleFluidModel())
         );
 
@@ -53,6 +57,16 @@ public final class ClientListener {
 
         PlaceableItemsPacketHandler.INSTANCE.sendToServer(new CNotifyItemPlaceKeyPacket(pressed));
         placeHandler.setHoldingKey(pressed);
+    }
+
+    /// For API use
+    /**
+     * Get an instance of the FluidHolderRenderer. {@link FluidModel}s should be bound here.
+     *
+     * @return the fluid holder renderer
+     */
+    public FluidHolderRenderer getFluidHolderRenderer() {
+        return fluidHolderRenderer;
     }
 
     public static ClientListener get() {

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
@@ -11,6 +11,8 @@ import me.ferdz.placeableitems.client.renderer.tileentity.FluidHolderRenderer;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.Vector3d;
 import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 
@@ -136,6 +138,24 @@ public abstract class FluidModel {
      */
     public FluidUVType getFluidUVType() {
         return FluidUVType.ELEMENT;
+    }
+
+    /**
+     * Get the light values to be used when rendering the fluid. It is recommended that this method
+     * only be overridden when a certain direction is improperly calculating light from its offset.
+     * For instance, the fluid at the top of a glass bottle still has access to light from the sides
+     * of the bottle even when a block is positioned above.
+     *
+     * @param world the world in which this model is being rendered
+     * @param pos the position at which this model is being renderer
+     * @param direction the direction from which the light should be calculated
+     *
+     * @return the light map values
+     *
+     * @see World#getCombinedLight(BlockPos, int)
+     */
+    public int getLight(World world, BlockPos pos, Direction direction) {
+        return world.getCombinedLight(pos.offset(direction), 0);
     }
 
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/FluidModel.java
@@ -4,7 +4,8 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 
 import me.ferdz.placeableitems.block.component.impl.FluidHolderBlockComponent;
-import me.ferdz.placeableitems.client.AllVertexBoundingBox;
+import me.ferdz.placeableitems.client.model.complex.FluidUVType;
+import me.ferdz.placeableitems.client.model.complex.ModelRenderDefinition;
 import me.ferdz.placeableitems.client.renderer.tileentity.FluidHolderRenderer;
 
 import net.minecraft.block.BlockState;
@@ -15,13 +16,13 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 
 /**
  * Represents a model definition for a fluid renderable in a {@link FluidHolderBlockComponent}.
- * Models should cache model data where possible (including rotation points and render bounds)
+ * Models should cache model data where possible (including rotation points and render elements)
  * and return them where necessary.
  * <p>
- * All states will have their render bounds cached and may be
+ * All states will have their render model definition cached and may be
  * recalculated at any time such that {@link #shouldRecalculate(BlockState)} returns true. Please
  * be cautious when returning true in the aforementioned method such that any computationally-expensive
- * calculations will be re-run (however {@link #calculateRenderBounds(BlockState)} is implemented).
+ * calculations will be re-run (however {@link #calculateModelDefinition(BlockState)} is implemented).
  * <p>
  * FluidModel implementations should be registered in a {@link FMLClientSetupEvent} with the
  * {@link FluidHolderRenderer#bind(me.ferdz.placeableitems.block.PlaceableItemsBlock, FluidModel)}
@@ -34,24 +35,24 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
  */
 public abstract class FluidModel {
 
-    private final Map<BlockState, AllVertexBoundingBox> renderCache = new IdentityHashMap<>();
+    private final Map<BlockState, ModelRenderDefinition> renderCache = new IdentityHashMap<>();
 
     /**
-     * Get the rendering bounds for this model from the render cache (if present). If a model is not
+     * Get the definition for this model from the render cache (if present). If a model is not
      * present, it will be calculated and cached. Additionally, the model will be recalculated if the
      * result of {@link #shouldRecalculate(BlockState)} is true.
      *
      * @param state the state whose model to retrieve
      *
-     * @return the rendering bounds
+     * @return the model definition
      */
-    public final AllVertexBoundingBox getRenderBounds(BlockState state) {
-        return shouldRecalculate(state) ? renderCache.compute(state, (s, existing) -> calculateRenderBounds(s)) : renderCache.computeIfAbsent(state, this::calculateRenderBounds);
+    public final ModelRenderDefinition getModelDefinition(BlockState state) {
+        return shouldRecalculate(state) ? renderCache.compute(state, (s, existing) -> calculateModelDefinition(s)) : renderCache.computeIfAbsent(state, this::calculateModelDefinition);
     }
 
     /**
-     * Calculate the rendering bounds for this model. This method does not account for cached models
-     * and should be used sparingly. Method callers should use {@link #getRenderBounds(BlockState)}
+     * Calculate the definition for this model. This method does not account for cached models and
+     * should be used sparingly. Method callers should use {@link #getModelDefinition(BlockState)}
      * instead to ensure a cached value is retrieved instead.
      * <p>
      * Implementations should consider the state's rotation and other states the block may have. Each
@@ -59,13 +60,13 @@ public abstract class FluidModel {
      * no model has yet been cached for the provided state, or {@link #shouldRecalculate(BlockState)}
      * returns true.
      * <p>
-     * These bounds support negative values and will be relative to {@link #getOrigin(BlockState)}.
+     * These definitions support negative values and will be relative to {@link #getOrigin(BlockState)}.
      *
-     * @param state the state whose render bounds to calculate
+     * @param state the state whose model definition to calculate
      *
-     * @return the rendering bounds
+     * @return the model definition
      */
-    public abstract AllVertexBoundingBox calculateRenderBounds(BlockState state);
+    public abstract ModelRenderDefinition calculateModelDefinition(BlockState state);
 
     /**
      * Check whether or not the provided state has been cached.
@@ -100,7 +101,7 @@ public abstract class FluidModel {
 
     /**
      * Get a pixel-scaled vector (values ranging from 0 - 16) for which this model may be rotated and positioned.
-     * {@link #calculateRenderBounds(BlockState)} will be rendered relative to this point. (0, 0, 0) is defined
+     * {@link #calculateModelDefinition(BlockState)} will be rendered relative to this point. (0, 0, 0) is defined
      * as the pixel positioned at the origin of the block relative to the floored block coordinates.
      * <p>
      * The point of origin will offset the rendering position and determine the point of rotation for this model.
@@ -112,12 +113,12 @@ public abstract class FluidModel {
     public abstract Vector3d getOrigin(BlockState state);
 
     /**
-     * Check whether or not the render bounds for the specified state should be recalculated. The
+     * Check whether or not the model definition for the specified state should be recalculated. The
      * result of this method is considered by the {@link FluidHolderRenderer} when fetching a cached
      * model.
      * <p>
-     * Caution should be had when overiding this method. Such that this method returns true, rendering
-     * bounds will be calculated for this state and {@link #calculateRenderBounds(BlockState)} will be
+     * Caution should be had when overiding this method. Such that this method returns true, the model
+     * definition will be calculated for this state and {@link #calculateModelDefinition(BlockState)} will be
      * invoked.
      *
      * @param state the state to check
@@ -126,6 +127,15 @@ public abstract class FluidModel {
      */
     public boolean shouldRecalculate(BlockState state) {
         return false;
+    }
+
+    /**
+     * Get the type of UV mapping to be used for this fluid model.
+     *
+     * @return the fluid UV mapping
+     */
+    public FluidUVType getFluidUVType() {
+        return FluidUVType.ELEMENT;
     }
 
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
@@ -9,6 +9,8 @@ import me.ferdz.placeableitems.init.PlaceableItemsBlockRegistry;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.Vector3d;
 import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 
 /**
  * An implementation of {@link FluidModel} for the {@link PlaceableItemsBlockRegistry#GLASS_BOTTLE}.
@@ -37,6 +39,21 @@ public class GlassBottleFluidModel extends FluidModel {
     @Override
     public boolean shouldRender(BlockState state, Direction direction) {
         return direction != Direction.DOWN;
+    }
+
+    @Override
+    public int getLight(World world, BlockPos pos, Direction direction) {
+        if (direction == Direction.UP) {
+            int light = super.getLight(world, pos, direction);
+            light |= super.getLight(world, pos, Direction.NORTH);
+            light |= super.getLight(world, pos, Direction.SOUTH);
+            light |= super.getLight(world, pos, Direction.EAST);
+            light |= super.getLight(world, pos, Direction.WEST);
+
+            return light;
+        }
+
+        return super.getLight(world, pos, direction);
     }
 
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/GlassBottleFluidModel.java
@@ -2,7 +2,8 @@ package me.ferdz.placeableitems.client.model;
 
 import me.ferdz.placeableitems.block.PlaceableItemsBlock;
 import me.ferdz.placeableitems.block.component.impl.BiPositionBlockComponent;
-import me.ferdz.placeableitems.client.AllVertexBoundingBox;
+import me.ferdz.placeableitems.client.model.complex.ModelRenderDefinition;
+import me.ferdz.placeableitems.client.model.complex.ModelRenderElement;
 import me.ferdz.placeableitems.init.PlaceableItemsBlockRegistry;
 
 import net.minecraft.block.BlockState;
@@ -19,11 +20,13 @@ public class GlassBottleFluidModel extends FluidModel {
     private static final Vector3d ORIGIN = new Vector3d(8.0D, 1.0D, 8.0D);
     private static final Vector3d UP_ORIGIN = new Vector3d(8.0D, 5.0D, 8.0D);
 
-    private static final AllVertexBoundingBox BOUNDS = AllVertexBoundingBox.fromAABB(-2.5 / 16.0, 0.0D, -2.5 / 16.0, 2.5 / 16.0, 4 / 16.0, 2.5 / 16.0);
+    private static final ModelRenderDefinition MODEL_DEFINITION = ModelRenderDefinition.withElements(
+            ModelRenderElement.fromAABB(-2.5 / 16.0, 0.0D, -2.5 / 16.0, 2.5 / 16.0, 4 / 16.0, 2.5 / 16.0)
+    );
 
     @Override
-    public AllVertexBoundingBox calculateRenderBounds(BlockState state) {
-        return BOUNDS.rotateAroundY(Math.toRadians((-state.get(PlaceableItemsBlock.ROTATION) * 360F / 16.0F)));
+    public ModelRenderDefinition calculateModelDefinition(BlockState state) {
+        return MODEL_DEFINITION.rotateAroundY(Math.toRadians((-state.get(PlaceableItemsBlock.ROTATION) * 360F / 16.0F)));
     }
 
     @Override

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/complex/FluidUVType.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/complex/FluidUVType.java
@@ -1,0 +1,27 @@
+package me.ferdz.placeableitems.client.model.complex;
+
+import me.ferdz.placeableitems.client.model.FluidModel;
+
+/**
+ * Represents a type of UV mapping for fluid model elements defined in a {@link FluidModel}
+ * or a {@link ModelRenderElement}.
+ *
+ * @author Parker Hawke - Choco
+ */
+public enum FluidUVType {
+
+    /**
+     * UV mappings will be relative to the model. For instance, if an element is defined from
+     * points (1, 4, 3) {@literal ->} (3, 6, 5), it will use the fluid texture from those same
+     * coordinates.
+     */
+    MODEL,
+
+    /**
+     * UV mappings will be stretched across the entire element. No matter where the element is
+     * defined relative to the model, the entire fluid texture will be rendered on the model and
+     * stretched to whatever size necessary.
+     */
+    ELEMENT;
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/complex/ModelRenderDefinition.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/complex/ModelRenderDefinition.java
@@ -1,0 +1,60 @@
+package me.ferdz.placeableitems.client.model.complex;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Represents a collection of {@link ModelRenderElement}s. This is an over-glorified collection
+ * wrapper with a few utility methods to collect and ease the rendering of multiple elements.
+ *
+ * @author Parker Hawke - Choco
+ */
+public class ModelRenderDefinition {
+
+    private final List<ModelRenderElement> elements;
+
+    private ModelRenderDefinition(List<ModelRenderElement> elements) {
+        this.elements = ImmutableList.copyOf(elements);
+    }
+
+    /**
+     * Create a ModelRenderDefinition with a set of render elements. These elements will be filtered
+     * to remove any null or duplicate elements.
+     *
+     * @param elements the elements to collect
+     *
+     * @return the model definition
+     */
+    public static ModelRenderDefinition withElements(ModelRenderElement... elements) {
+        return new ModelRenderDefinition(Arrays.stream(elements).filter(Objects::nonNull).distinct().collect(Collectors.toList()));
+    }
+
+    /**
+     * Get a list of all the elements in this definition. The returned collection is immutable.
+     *
+     * @return the elements
+     */
+    public List<ModelRenderElement> getElements() {
+        return elements;
+    }
+
+    /**
+     * Rotate this render definition clockwise around the y axis.
+     *
+     * @param radians the amount (in radians) by which to rotate this bounding box.
+     *
+     * @return a new {@link ModelRenderDefinition} rotated clockwise by the specified radians.
+     * All contained elements will also be new (therefore will not be == to one another)
+     *
+     * @see ModelRenderElement#rotateAroundY(double)
+     */
+    public ModelRenderDefinition rotateAroundY(double radians) {
+        List<ModelRenderElement> rotatedElements = elements.stream().map(b -> b.rotateAroundY(radians)).collect(Collectors.toList());
+        return new ModelRenderDefinition(rotatedElements);
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/model/complex/ModelRenderElement.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/model/complex/ModelRenderElement.java
@@ -1,18 +1,19 @@
-package me.ferdz.placeableitems.client;
+package me.ferdz.placeableitems.client.model.complex;
+
+import me.ferdz.placeableitems.client.model.FluidModel;
 
 import net.minecraft.client.renderer.Vector3d;
 import net.minecraft.util.math.AxisAlignedBB;
 
 /**
- * Represents a box defined by 8 points in the world. Unlike {@link AxisAlignedBB}s, points
- * are not validated. Therefore, caution must be taken when creating instances of this box
- * as some points may not be properly named according to this class' member methods. The
- * methods are named according to their position in the world relative to the player when facing
- * the bounding box.
+ * Represents an element defined by 8 points. Unlike {@link AxisAlignedBB}s, points are not
+ * validated, therefore caution must be taken when creating instances of this box as some points
+ * may not be properly named according to this class' member methods. The methods are named
+ * according to their position in the world relative to the player when facing the element.
  *
  * @author Parker Hawke - Choco
  */
-public class AllVertexBoundingBox {
+public class ModelRenderElement {
 
     private final Vector3d frontBottomLeft, frontBottomRight;
     private final Vector3d frontTopLeft, frontTopRight;
@@ -20,8 +21,10 @@ public class AllVertexBoundingBox {
     private final Vector3d backBottomLeft, backBottomRight;
     private final Vector3d backTopLeft, backTopRight;
 
+    private FluidUVType uvType = null;
+
     /**
-     * Create an AllVertexBoundingBox with all 8 vertexes. It is recommended that a builder be
+     * Create a {@link ModelRenderElement} with all 8 vertices. It is recommended that a builder be
      * used instead. See {@link #create()} or {@link #fromAABB(AxisAlignedBB)}.
      *
      * @param frontBottomLeft the front, bottom left vertex
@@ -33,7 +36,7 @@ public class AllVertexBoundingBox {
      * @param backTopLeft the back, top left vertex
      * @param backTopRight the back, top right vertex
      */
-    public AllVertexBoundingBox(Vector3d frontBottomLeft, Vector3d frontBottomRight, Vector3d frontTopLeft, Vector3d frontTopRight, Vector3d backBottomLeft, Vector3d backBottomRight, Vector3d backTopLeft, Vector3d backTopRight) {
+    public ModelRenderElement(Vector3d frontBottomLeft, Vector3d frontBottomRight, Vector3d frontTopLeft, Vector3d frontTopRight, Vector3d backBottomLeft, Vector3d backBottomRight, Vector3d backTopLeft, Vector3d backTopRight) {
         this.frontBottomLeft = frontBottomLeft;
         this.frontBottomRight = frontBottomRight;
         this.frontTopLeft = frontTopLeft;
@@ -45,22 +48,22 @@ public class AllVertexBoundingBox {
     }
 
     /**
-     * Create an {@link AllVertexBoundingBox} based on an AxisAlignedBB. The missing vertices will
-     * be calculated based on the min and max points from the provided bounds. The created bounding
-     * box will therefore match the bounds of the one provided.
+     * Create a {@link ModelRenderElement} based on an AxisAlignedBB. The missing vertices will
+     * be calculated based on the min and max points from the provided bounds. The created element
+     * will therefore match the bounds of the provided bounding box.
      *
-     * @param bounds the bounding box from which to create an AllVertexBoundingBox
+     * @param bounds the bounding box from which to copy vertices
      *
-     * @return the newly created AllVertexBoundingBox
+     * @return the newly created ModelRenderElement
      */
-    public static AllVertexBoundingBox fromAABB(AxisAlignedBB bounds) {
+    public static ModelRenderElement fromAABB(AxisAlignedBB bounds) {
         return fromAABB(bounds.minX, bounds.minY, bounds.minZ, bounds.maxX, bounds.maxY, bounds.maxZ);
     }
 
     /**
-     * Create an {@link AllVertexBoundingBox} based on a set of coordinates. The missing vertices will
-     * be calculated based on the min and max points from the provided bounds. The created bounding
-     * box will therefore match the bounds of the one provided.
+     * Create a {@link ModelRenderElement} based on a set of coordinates. The missing vertices will
+     * be calculated based on the min and max points from the provided bounds. The created element
+     * will therefore match the bounds of the provided bounding box.
      *
      * @param x the first x coordinate
      * @param y the first y coordinate
@@ -69,9 +72,9 @@ public class AllVertexBoundingBox {
      * @param deltaY the second y coordinate
      * @param deltaZ the second z coordinate
      *
-     * @return the newly created AllVertexBoundingBox
+     * @return the newly created ModelRenderElement
      */
-    public static AllVertexBoundingBox fromAABB(double x, double y, double z, double deltaX, double deltaY, double deltaZ) {
+    public static ModelRenderElement fromAABB(double x, double y, double z, double deltaX, double deltaY, double deltaZ) {
         double minX = Math.min(x, deltaX);
         double minY = Math.min(y, deltaY);
         double minZ = Math.min(z, deltaZ);
@@ -90,16 +93,16 @@ public class AllVertexBoundingBox {
     }
 
     /**
-     * Get a builder instance to create an {@link AllVertexBoundingBox}.
+     * Get a builder instance to create a {@link ModelRenderElement}.
      *
      * @return the builder instance
      */
-    public static AllVertexBoundingBox.Builder create() {
-        return new AllVertexBoundingBox.Builder();
+    public static ModelRenderElement.Builder create() {
+        return new ModelRenderElement.Builder();
     }
 
     /**
-     * Get the front, bottom left vertex of this bounding box.
+     * Get the front, bottom left vertex of this element.
      *
      * @return the front, bottom left vertex
      */
@@ -108,7 +111,7 @@ public class AllVertexBoundingBox {
     }
 
     /**
-     * Get the front, bottom right vertex of this bounding box.
+     * Get the front, bottom right vertex of this element.
      *
      * @return the front, bottom right vertex
      */
@@ -117,7 +120,7 @@ public class AllVertexBoundingBox {
     }
 
     /**
-     * Get the front, top left vertex of this bounding box.
+     * Get the front, top left vertex of this element.
      *
      * @return the front, top left vertex
      */
@@ -126,7 +129,7 @@ public class AllVertexBoundingBox {
     }
 
     /**
-     * Get the front, top right vertex of this bounding box.
+     * Get the front, top right vertex of this element.
      *
      * @return the front, top right vertex
      */
@@ -135,7 +138,7 @@ public class AllVertexBoundingBox {
     }
 
     /**
-     * Get the back, bottom left vertex of this bounding box.
+     * Get the back, bottom left vertex of this element.
      *
      * @return the back, bottom left vertex
      */
@@ -144,7 +147,7 @@ public class AllVertexBoundingBox {
     }
 
     /**
-     * Get the back, bottom right vertex of this bounding box.
+     * Get the back, bottom right vertex of this element.
      *
      * @return the back, bottom right vertex
      */
@@ -153,7 +156,7 @@ public class AllVertexBoundingBox {
     }
 
     /**
-     * Get the back, top left vertex of this bounding box.
+     * Get the back, top left vertex of this element.
      *
      * @return the back, top left vertex
      */
@@ -162,7 +165,7 @@ public class AllVertexBoundingBox {
     }
 
     /**
-     * Get the back, top right vertex of this bounding box.
+     * Get the back, top right vertex of this element.
      *
      * @return the back, top right vertex
      */
@@ -171,13 +174,35 @@ public class AllVertexBoundingBox {
     }
 
     /**
-     * Rotate this bounding box clockwise around the y axis.
+     * Get the UV type to use for this element when rendering.
+     *
+     * @return the fluid uv type
+     */
+    public FluidUVType getUVType() {
+        return uvType;
+    }
+
+    /**
+     * Set the UV type to use for this element when rendering. This UV type will override
+     * that specified by {@link FluidModel#getFluidUVType()}.
+     *
+     * @param uvType the UV type to set
+     *
+     * @return this instance. Allows for chained method calls
+     */
+    public ModelRenderElement setUVType(FluidUVType uvType) {
+        this.uvType = uvType;
+        return this;
+    }
+
+    /**
+     * Rotate this element clockwise around the y axis.
      *
      * @param radians the amount (in radians) by which to rotate this bounding box.
      *
-     * @return a new {@link AllVertexBoundingBox} rotated clockwise by the specified radians
+     * @return a new {@link ModelRenderElement} rotated clockwise by the specified radians
      */
-    public AllVertexBoundingBox rotateAroundY(double radians) {
+    public ModelRenderElement rotateAroundY(double radians) {
         double sin = Math.sin(radians), cos = Math.cos(radians);
 
         double frontBottomLeftRotatedX = (frontBottomLeft.x * cos) + (frontBottomLeft.z * sin);
@@ -258,8 +283,8 @@ public class AllVertexBoundingBox {
             return this;
         }
 
-        public AllVertexBoundingBox build() {
-            return new AllVertexBoundingBox(frontBottomLeft, frontBottomRight, frontTopLeft, frontTopRight, backBottomLeft, backBottomRight, backTopLeft, backTopRight);
+        public ModelRenderElement build() {
+            return new ModelRenderElement(frontBottomLeft, frontBottomRight, frontTopLeft, frontTopRight, backBottomLeft, backBottomRight, backTopLeft, backTopRight);
         }
 
     }

--- a/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/client/renderer/tileentity/FluidHolderRenderer.java
@@ -114,7 +114,7 @@ public class FluidHolderRenderer extends TileEntityRendererFast<FluidHolderTileE
             // Conditionally cull and render specific directions
             if (model.shouldRender(state, Direction.DOWN)) {
                 // Fetch the value of the lights that strike this quad
-                int downCombined = getWorld().getCombinedLight(pos.down(), 0);
+                int downCombined = model.getLight(getWorld(), pos, Direction.DOWN);
                 int downLMa = downCombined >> 16 & 65535;
                 int downLMb = downCombined & 65535;
 
@@ -126,7 +126,7 @@ public class FluidHolderRenderer extends TileEntityRendererFast<FluidHolderTileE
             }
 
             if (model.shouldRender(state, Direction.UP)) {
-                int upCombined = getWorld().getCombinedLight(pos.up(), 0);
+                int upCombined = model.getLight(getWorld(), pos, Direction.UP);
                 int upLMa = upCombined >> 16 & 65535;
                 int upLMb = upCombined & 65535;
 
@@ -137,7 +137,7 @@ public class FluidHolderRenderer extends TileEntityRendererFast<FluidHolderTileE
             }
 
             if (model.shouldRender(state, Direction.NORTH)) {
-                int northCombined = getWorld().getCombinedLight(pos.north(), 0);
+                int northCombined = model.getLight(getWorld(), pos, Direction.NORTH);
                 int northLMa = northCombined >> 16 & 65535;
                 int northLMb = northCombined & 65535;
 
@@ -148,7 +148,7 @@ public class FluidHolderRenderer extends TileEntityRendererFast<FluidHolderTileE
             }
 
             if (model.shouldRender(state, Direction.SOUTH)) {
-                int southCombined = getWorld().getCombinedLight(pos.south(), 0);
+                int southCombined = model.getLight(getWorld(), pos, Direction.SOUTH);
                 int southLMa = southCombined >> 16 & 65535;
                 int southLMb = southCombined & 65535;
 
@@ -159,7 +159,7 @@ public class FluidHolderRenderer extends TileEntityRendererFast<FluidHolderTileE
             }
 
             if (model.shouldRender(state, Direction.WEST)) {
-                int westCombined = getWorld().getCombinedLight(pos.west(), 0);
+                int westCombined = model.getLight(getWorld(), pos, Direction.WEST);
                 int westLMa = westCombined >> 16 & 65535;
                 int westLMb = westCombined & 65535;
 
@@ -170,7 +170,7 @@ public class FluidHolderRenderer extends TileEntityRendererFast<FluidHolderTileE
             }
 
             if (model.shouldRender(state, Direction.EAST)) {
-                int eastCombined = getWorld().getCombinedLight(pos.east(), 0);
+                int eastCombined = model.getLight(getWorld(), pos, Direction.EAST);
                 int eastLMa = eastCombined >> 16 & 65535;
                 int eastLMb = eastCombined & 65535;
 


### PR DESCRIPTION
After the addition of the recent FluidModel API for fluid containers, it became clear that work needed to be done to support the rendering of multiple elements rather than just one cube. This PR aims to make this API/library more flexible as well as add a few more features in preparation for the bucket becoming a fluid container.
- Exposes the `FluidHolderRenderer` in the `ClientListener` for API use
- Rename `AllAxisBoundingBox` -> `ModelRenderElement`
- Add `ModelRenderDefinition` to collect multiple `ModelRenderElement` among other useful methods
- Add `FluidUVType` constants and let `ModelRenderElement` and `FluidModel` each define constants of their own
  - `FluidModel#getFluidUVType()` which defaults to `ELEMENT`
  - `ModelRenderElement#setUVType()`. This defaults to whatever is set in the FluidModel
- Add `FluidModel#getLight()` to override light calculations for a specific direction. This helps fix fluid textures being blackened when a block is above a model
- Shifted model-related classes (`ModelRenderElement`, `ModelRenderDefinition` and `FluidUVType`) to their own package, `me.ferdz.placeableitems.client.model.complex`

All the above should be documented. The reason for the UV changes is due to the bucket which will be added in a future PR (it's actually complete as I used it as a base to this PR). Because it uses 3 different elements, each individual element uses the whole fluid UV mapping which does NOT look good whatsoever. Forcing a model to compute UV values based on its elements positions makes the fluid texture look a lot more fluid as though it's in the world.

The changes have not yet been ported to Fabric. This may be done after changes have been made upon further review. Changes will be identical (and can be mostly copy/pasted) into Fabric.

These new UV values were also tried on the existing glass bottle. If the changes are preferred, they may be included. Though for now, they remain identical to the values prior to this PR. The changes are subtle for single-element objects, but certainly noticeable.

**FluidUVType.ELEMENT (current):**
![element](https://i.imgur.com/zI5CaKc.png)

**FluidUVType.MODEL (new):**
![model](https://i.imgur.com/sMkzap1.png)