### PR TITLE
Move TileEntityType registry to its own class & fix valid tile blocks

### DIFF
--- a/Forge/src/main/java/me/ferdz/placeableitems/block/PlaceableItemsBlockBuilder.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/block/PlaceableItemsBlockBuilder.java
@@ -1,9 +1,12 @@
 package me.ferdz.placeableitems.block;
 
 import me.ferdz.placeableitems.block.component.IBlockComponent;
+import me.ferdz.placeableitems.init.PlaceableItemsTileEntityTypeRegistry;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.state.StateContainer;
+import net.minecraft.tileentity.TileEntity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +25,7 @@ public class PlaceableItemsBlockBuilder {
     }
 
     public PlaceableItemsBlock build() {
-        return new PlaceableItemsBlock() {
+        PlaceableItemsBlock block = new PlaceableItemsBlock() {
             @Override
             protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
                 super.fillStateContainer(builder);
@@ -33,5 +36,15 @@ public class PlaceableItemsBlockBuilder {
                 }
             }
         }.addComponents(this.components);
+
+        // Ensure all tile entities created by its components declare it as a valid block
+        block.getComponents().forEach(component -> {
+            Class<? extends TileEntity> tileEntityClass = component.getTileEntityClass(null);
+            if (tileEntityClass != null) {
+                PlaceableItemsTileEntityTypeRegistry.assignTo(tileEntityClass, block);
+            }
+        });
+
+        return block;
     }
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/block/component/AbstractBlockComponent.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/block/component/AbstractBlockComponent.java
@@ -20,7 +20,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.storage.loot.LootContext;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -50,7 +50,7 @@ public abstract class AbstractBlockComponent implements IBlockComponent {
 
     @Override
     public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
-        return new ArrayList<>();
+        return Collections.emptyList();
     }
 
     @Override
@@ -60,7 +60,12 @@ public abstract class AbstractBlockComponent implements IBlockComponent {
 
     @Override
     public boolean hasTileEntity(BlockState state) {
-        return false;
+        return getTileEntityClass(state) != null;
+    }
+
+    @Override
+    public Class<? extends TileEntity> getTileEntityClass(BlockState state) {
+        return null;
     }
 
     @Nullable

--- a/Forge/src/main/java/me/ferdz/placeableitems/block/component/IBlockComponent.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/block/component/IBlockComponent.java
@@ -60,6 +60,16 @@ public interface IBlockComponent {
     boolean hasTileEntity(BlockState state);
 
     /**
+     * Get the class of the tile entity this component provides. The provided state may be null, therefore
+     * this should be taken into consideration. The default tile entity should be returned instead.
+     *
+     * @param state the state for which to get the tile entity class
+     *
+     * @return the tile entity class
+     */
+    Class<? extends TileEntity> getTileEntityClass(BlockState state);
+
+    /**
      * {@link net.minecraftforge.common.extensions.IForgeBlock#createTileEntity(BlockState, IBlockReader)}
      */
     @Nullable

--- a/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/FluidHolderBlockComponent.java
@@ -222,8 +222,8 @@ public class FluidHolderBlockComponent extends AbstractBlockComponent {
     }
 
     @Override
-    public boolean hasTileEntity(BlockState state) {
-        return true;
+    public Class<? extends TileEntity> getTileEntityClass(BlockState state) {
+        return FluidHolderTileEntity.class;
     }
 
     @Override

--- a/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/HorseArmorStandBlockComponent.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/HorseArmorStandBlockComponent.java
@@ -1,7 +1,7 @@
 package me.ferdz.placeableitems.block.component.impl;
 
 import me.ferdz.placeableitems.block.component.AbstractBlockComponent;
-import me.ferdz.placeableitems.init.PlaceableItemsItemsRegistry;
+import me.ferdz.placeableitems.init.PlaceableItemsItemRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
@@ -24,7 +24,7 @@ public class HorseArmorStandBlockComponent extends AbstractBlockComponent {
 
     @Override
     public Item asItem() {
-        return PlaceableItemsItemsRegistry.HORSE_ARMOR_STAND;
+        return PlaceableItemsItemRegistry.HORSE_ARMOR_STAND;
     }
 //
 //    @Override

--- a/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/SaddleStandBlockComponent.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/SaddleStandBlockComponent.java
@@ -2,7 +2,7 @@ package me.ferdz.placeableitems.block.component.impl;
 
 import me.ferdz.placeableitems.block.component.AbstractBlockComponent;
 import me.ferdz.placeableitems.init.PlaceableItemsBlockRegistry;
-import me.ferdz.placeableitems.init.PlaceableItemsItemsRegistry;
+import me.ferdz.placeableitems.init.PlaceableItemsItemRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
@@ -29,7 +29,7 @@ public class SaddleStandBlockComponent extends AbstractBlockComponent {
 
     @Override
     public Item asItem() {
-        return PlaceableItemsItemsRegistry.SADDLE_STAND;
+        return PlaceableItemsItemRegistry.SADDLE_STAND;
     }
 
     @Override

--- a/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/StackHolderBlockComponent.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/block/component/impl/StackHolderBlockComponent.java
@@ -13,7 +13,6 @@ import net.minecraft.world.storage.loot.LootContext;
 import net.minecraft.world.storage.loot.LootParameters;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -25,25 +24,27 @@ public class StackHolderBlockComponent extends AbstractBlockComponent {
             return;
         }
 
-        StackHolderTileEntity tileEntity = (StackHolderTileEntity) worldIn.getTileEntity(pos);
-        if (tileEntity == null) {
+        TileEntity tileEntity = worldIn.getTileEntity(pos);
+        if (!(tileEntity instanceof StackHolderTileEntity)) {
             return;
         }
-        tileEntity.setItemStack(stack);
+
+        ((StackHolderTileEntity) tileEntity).setItemStack(stack);
     }
 
     @Override
     public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
-        StackHolderTileEntity tileEntity = (StackHolderTileEntity) builder.get(LootParameters.BLOCK_ENTITY);
-        if (tileEntity == null) {
-            return new ArrayList<>();
+        TileEntity tileEntity = builder.get(LootParameters.BLOCK_ENTITY);
+        if (!(tileEntity instanceof StackHolderTileEntity)) {
+            return Collections.emptyList();
         }
-        return Collections.singletonList(tileEntity.getItemStack());
+
+        return Collections.singletonList(((StackHolderTileEntity) tileEntity).getItemStack());
     }
 
     @Override
-    public boolean hasTileEntity(BlockState state) {
-        return true;
+    public Class<? extends TileEntity> getTileEntityClass(BlockState state) {
+        return StackHolderTileEntity.class;
     }
 
     @Nullable

--- a/Forge/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsBlockRegistry.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsBlockRegistry.java
@@ -1,11 +1,8 @@
 package me.ferdz.placeableitems.init;
 
-import me.ferdz.placeableitems.PlaceableItems;
 import me.ferdz.placeableitems.block.PlaceableItemsBlock;
 import me.ferdz.placeableitems.block.PlaceableItemsBlockBuilder;
 import me.ferdz.placeableitems.block.component.impl.*;
-import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
-import me.ferdz.placeableitems.tileentity.StackHolderTileEntity;
 import me.ferdz.placeableitems.utils.VoxelShapesUtil;
 import me.ferdz.placeableitems.wiki.WikiDefinition;
 import net.minecraft.block.Block;
@@ -13,7 +10,6 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.passive.ChickenEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.math.shapes.VoxelShapes;
 
 import net.minecraftforge.event.RegistryEvent;
@@ -22,7 +18,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.registries.IForgeRegistry;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
-public class PlaceableItemsBlockRegistry {
+public final class PlaceableItemsBlockRegistry {
 
     @WikiDefinition(model = "apple_down" )
     public static PlaceableItemsBlock APPLE;
@@ -207,6 +203,8 @@ public class PlaceableItemsBlockRegistry {
 
     public static PlaceableItemsBlock HORSE_ARMOR_STAND;
     public static PlaceableItemsBlock SADDLE_STAND;
+
+    private PlaceableItemsBlockRegistry() {}
 
     @SubscribeEvent
     public static void onBlocksRegistry(final RegistryEvent.Register<Block> event) {
@@ -577,19 +575,4 @@ public class PlaceableItemsBlockRegistry {
                 .register("saddle_stand_block", registry);
     }
 
-    // TODO: Move this section to a TE registry
-
-    public static TileEntityType<?> WRITABLE_BOOK_TILE_ENTITY;
-
-    @SubscribeEvent
-    public static void registerTE(RegistryEvent.Register<TileEntityType<?>> e) {
-        WRITABLE_BOOK_TILE_ENTITY = TileEntityType.Builder
-                .create(StackHolderTileEntity::new, WRITABLE_BOOK)
-                .build(null)
-                .setRegistryName(PlaceableItems.MODID, "writable_book_block");
-        e.getRegistry().registerAll(
-                WRITABLE_BOOK_TILE_ENTITY,
-                TileEntityType.Builder.create(FluidHolderTileEntity::new, GLASS_BOTTLE).build(null).setRegistryName(PlaceableItems.MODID, "fluid_holder")
-        );
-    }
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsItemRegistry.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsItemRegistry.java
@@ -8,12 +8,12 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
-public final class PlaceableItemsItemsRegistry {
+public final class PlaceableItemsItemRegistry {
 
     public static Item HORSE_ARMOR_STAND;
     public static Item SADDLE_STAND;
 
-    private PlaceableItemsItemsRegistry() { }
+    private PlaceableItemsItemRegistry() { }
 
     @SubscribeEvent
     public static void onItemsRegistry(final RegistryEvent.Register<Item> event) {

--- a/Forge/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsItemsRegistry.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsItemsRegistry.java
@@ -8,10 +8,12 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
-public class PlaceableItemsItemsRegistry {
+public final class PlaceableItemsItemsRegistry {
 
     public static Item HORSE_ARMOR_STAND;
     public static Item SADDLE_STAND;
+
+    private PlaceableItemsItemsRegistry() { }
 
     @SubscribeEvent
     public static void onItemsRegistry(final RegistryEvent.Register<Item> event) {
@@ -25,4 +27,5 @@ public class PlaceableItemsItemsRegistry {
                 .setRegistryName("saddle_stand_item");
         event.getRegistry().register(SADDLE_STAND);
     }
+
 }

--- a/Forge/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsTileEntityTypeRegistry.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsTileEntityTypeRegistry.java
@@ -1,0 +1,46 @@
+package me.ferdz.placeableitems.init;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+
+import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
+import me.ferdz.placeableitems.tileentity.StackHolderTileEntity;
+
+import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityType;
+
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+
+@EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD)
+public final class PlaceableItemsTileEntityTypeRegistry {
+
+    private static final Multimap<Class<? extends TileEntity>, Block> VALID_BLOCKS = MultimapBuilder.hashKeys().arrayListValues().build();
+
+    private PlaceableItemsTileEntityTypeRegistry() { }
+
+    @SubscribeEvent
+    public static void registerTE(RegistryEvent.Register<TileEntityType<?>> e) {
+        e.getRegistry().registerAll(
+                registerWithBlocks(StackHolderTileEntity::new, StackHolderTileEntity.class).setRegistryName("writable_book_block"),
+                registerWithBlocks(FluidHolderTileEntity::new, FluidHolderTileEntity.class).setRegistryName("fluid_holder")
+        );
+    }
+
+    public static void assignTo(Class<? extends TileEntity> tileEntity, Block block) {
+        VALID_BLOCKS.put(tileEntity, block);
+    }
+
+    private static <T extends TileEntity> TileEntityType<T> registerWithBlocks(Supplier<T> factory, Class<T> tileClass) {
+        Collection<Block> validBlocks = VALID_BLOCKS.removeAll(tileClass); // removeAll() because we won't need these values again
+        TileEntityType<T> type = TileEntityType.Builder.create(factory, validBlocks.toArray(new Block[validBlocks.size()])).build(null);
+        return type;
+    }
+
+}

--- a/Forge/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsTileEntityTypeRegistry.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/init/PlaceableItemsTileEntityTypeRegistry.java
@@ -6,6 +6,7 @@ import java.util.function.Supplier;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 
+import me.ferdz.placeableitems.PlaceableItems;
 import me.ferdz.placeableitems.tileentity.FluidHolderTileEntity;
 import me.ferdz.placeableitems.tileentity.StackHolderTileEntity;
 
@@ -28,8 +29,8 @@ public final class PlaceableItemsTileEntityTypeRegistry {
     @SubscribeEvent
     public static void registerTE(RegistryEvent.Register<TileEntityType<?>> e) {
         e.getRegistry().registerAll(
-                registerWithBlocks(StackHolderTileEntity::new, StackHolderTileEntity.class).setRegistryName("writable_book_block"),
-                registerWithBlocks(FluidHolderTileEntity::new, FluidHolderTileEntity.class).setRegistryName("fluid_holder")
+                registerWithBlocks(StackHolderTileEntity::new, StackHolderTileEntity.class).setRegistryName(PlaceableItems.MODID, "writable_book_block"),
+                registerWithBlocks(FluidHolderTileEntity::new, FluidHolderTileEntity.class).setRegistryName(PlaceableItems.MODID, "fluid_holder")
         );
     }
 

--- a/Forge/src/main/java/me/ferdz/placeableitems/tileentity/StackHolderTileEntity.java
+++ b/Forge/src/main/java/me/ferdz/placeableitems/tileentity/StackHolderTileEntity.java
@@ -1,24 +1,23 @@
 package me.ferdz.placeableitems.tileentity;
 
-import me.ferdz.placeableitems.init.PlaceableItemsBlockRegistry;
+import me.ferdz.placeableitems.PlaceableItems;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.network.NetworkManager;
-import net.minecraft.network.play.server.SUpdateTileEntityPacket;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
-import net.minecraftforge.items.ItemStackHandler;
-
-import javax.annotation.Nullable;
+import net.minecraftforge.registries.ObjectHolder;
 
 public class StackHolderTileEntity extends TileEntity {
+
+    @ObjectHolder(PlaceableItems.MODID + ":writable_book_block")
+    public static final TileEntityType<StackHolderTileEntity> TYPE = null;
 
     private static final String ITEM_STACK_KEY = "PlaceableItems-Stack";
 
     private ItemStack itemStack = ItemStack.EMPTY;
 
     public StackHolderTileEntity() {
-        super(PlaceableItemsBlockRegistry.WRITABLE_BOOK_TILE_ENTITY);
+        super(TYPE);
     }
 
     @Override


### PR DESCRIPTION
This PR addresses 1 technical enhancement from #72 as well as addresses a lesser known, rare issue that may occur on some servers under very specific circumstances.
- Moves all tile entity type registration to its own class, `PlaceableItemsTileEntityTypeRegistry`
- Moves the `WRITABLE_BOOK_TILE_ENTITY` constant from `PlaceableItemsBlockRegistry` to the `StackHolderTileEntity` class and renamed it to `TYPE` (to match that of `FluidHolderTileEntity`)
  - **Note for the future:** The registry ID should really be changed, but this involves data fixers which are severely under-documented and overly complex.
- Adds a new method to `IBlockComponent` to fetch the class of the tile entity created by the component. Used for internal reasons:
  - This helps dynamically register valid blocks for tile entities which was not done previously. Only writable books were considered valid blocks of the stack holder
  - Previously, valid block entries had to be added manually with hard-coding. This now handles them dynamically
- More safely access the tile entity in `StackHolderBlockComponent` as there was a possibility for ClassCastExceptions if the tile entity was no longer present or of the wrong type
- Better encapsulate the registry classes by finalizing them and creating private constructors. No reason for instances of these classes to be floating around.

I'm unsure if the method in `IBlockComponent` is the _correct_ approach, but it's the only approach I could think of. Because tile entities are registered _after_ block registration, it makes it difficult to reference their type constants because at the point of block registration, these are not yet populated and remain null. Therefore, supplying the class through the component made the most sense.