### PR TITLE
Implement Waterlogging

### DIFF
--- a/src/main/java/me/ferdz/placeableitems/block/RotationBlock.java
+++ b/src/main/java/me/ferdz/placeableitems/block/RotationBlock.java
@@ -81,10 +81,10 @@ public class RotationBlock extends Block implements SimpleWaterloggedBlock {
     }
 
     @Override
-    public BlockState updateShape(BlockState state, Direction direction, BlockState neighborState, LevelAccessor level, BlockPos pos, BlockPos neighborPos) { //
-        if (state.getValue(WATERLOGGED)) { //
-            level.scheduleTick(pos, Fluids.WATER, Fluids.WATER.getTickDelay(level)); //
+    public BlockState updateShape(BlockState state, Direction direction, BlockState neighborState, LevelAccessor level, BlockPos pos, BlockPos neighborPos) {
+        if (state.getValue(WATERLOGGED)) {
+            level.scheduleTick(pos, Fluids.WATER, Fluids.WATER.getTickDelay(level));
         }
-        return super.updateShape(state, direction, neighborState, level, pos, neighborPos); //
+        return super.updateShape(state, direction, neighborState, level, pos, neighborPos);
     }
 }


### PR DESCRIPTION
This PR implements the waterlogging feature for all mod blocks that use the RotationBlock base class, including the Saddle Stand, HorseArmorStand and all placeable items.

This functionality addresses Issue #63 and ensures greater parity with Vanilla Minecraft, offering more decoration and immersion options.

**Proposed Solution**

The base class `RotationBlock.java` now implements the native Minecraft interface `SimpleWaterloggedBlock`.

The block state property `WATERLOGGED` has been added to the state definition in `RotationBlock`.

The logic for setting the `WATERLOGGED` state during block placement (`getStateForPlacement`), along with essential fluid handling methods (`getFluidState`() and `updateShape()`), has been implemented in `RotationBlock.java`.
